### PR TITLE
Renamed blocks to closures

### DIFF
--- a/SugarRecord/NSManagedObjectContext/NSManagedObjectContext+Operations.swift
+++ b/SugarRecord/NSManagedObjectContext/NSManagedObjectContext+Operations.swift
@@ -42,7 +42,7 @@ extension NSManagedObjectContext {
             })
         }
         
-        var saveBlock: () -> () = {
+        var saveClosure: () -> () = {
             var saveResult: Bool = false
             var error: NSError?
             saveResult = self.save(&error)
@@ -64,10 +64,10 @@ extension NSManagedObjectContext {
         
         // Saving otherwise
         if synchronously {
-            self.performBlockAndWait(saveBlock)
+            self.performBlockAndWait(saveClosure)
         }
         else {
-            self.performBlock(saveBlock)
+            self.performBlock(saveClosure)
         }
     }
 }

--- a/SugarRecord/SugarRecord+Operations.swift
+++ b/SugarRecord/SugarRecord+Operations.swift
@@ -10,39 +10,42 @@ import Foundation
 
 // MARK - SugarRecord Operations
 
-public extension SugarRecord {
+public extension SugarRecord
+    {
     /**
-     Executes a closure block pasing a context as an input paramter to the closure and saving the context changes before deleting it
+     Executes a closure pasing a context as an input paramter to the closure and saving the context changes before deleting it
 
      :param: background  Indicates if the saving is going to be executed in background
-     :param: savingBlock Closure to be executed. Context passed is a private context
+     :param: savingClosure Closure to be executed. Context passed is a private context
      */
-    class func save(inBackground background: Bool, savingBlock: (context: NSManagedObjectContext) -> (), completion: (success: Bool, error: NSError?) -> ()) {
-        SugarRecord.save(true, savingBlock: savingBlock, completion: completion)
+    class func save(inBackground background: Bool, savingClosure: (context: NSManagedObjectContext) -> (), completion: (success: Bool, error: NSError?) -> ())
+    {
+        SugarRecord.save(true, savingClosure: savingClosure, completion: completion)
     }
     
 
     /**
-    Executes a closure block in background pasing a context as an input paramter to the closure and saving the context changes before deleting it
+    Executes a closure in background pasing a context as an input paramter to the closure and saving the context changes before deleting it
 
 
      :param: synchronously Bool indicating if the saving is going to be synchronous
-     :param: savingBlock   Closure to be executed. Context passed is a private context
+     :param: savingClosure   Closure to be executed. Context passed is a private context
      */
-    private class func save(synchronously: Bool, savingBlock: (context: NSManagedObjectContext) -> (), completion: (success: Bool, error: NSError?) -> ()) {
+    private class func save(synchronously: Bool, savingClosure: (context: NSManagedObjectContext) -> (), completion: (success: Bool, error: NSError?) -> ())
+    {
         // Generating context
         let privateContext: NSManagedObjectContext = NSManagedObjectContext.newContextWithParentContext(NSManagedObjectContext.rootSavingContext()!)
         
-        // Executing block
+        // Executing closure
         if synchronously {
             privateContext.performBlockAndWait({ () -> Void in
-                savingBlock(context: privateContext)
+                savingClosure(context: privateContext)
                 privateContext.save(true, savingParents: true, completion: completion)
             })
         }
         else {
             privateContext.performBlock({ () -> Void in
-                savingBlock(context: privateContext)
+                savingClosure(context: privateContext)
                 privateContext.save(false, savingParents: true, completion: completion)
             })
         }
@@ -51,20 +54,14 @@ public extension SugarRecord {
     /**
      Executes a closure operatin in background but without saving the context used in background.
 
-     :param: block Closure that is going to be executed
+     :param: Closure that is going to be executed
      */
-    class func background(block: (context: NSManagedObjectContext) -> ()) {
-        self.save(inBackground: true, savingBlock: { (context) -> () in
-            
-        }) { (success, error) -> () in
-            
-        }
-        
+    class func background(closure: (context: NSManagedObjectContext) -> ())
+    {
         var privateContext: NSManagedObjectContext = NSManagedObjectContext.newContextWithParentContext(NSManagedObjectContext.rootSavingContext()!)
         privateContext.performBlockAndWait({ () -> Void in
-            block(context: privateContext)
+            closure(context: privateContext)
         })
     
     }
-
 }

--- a/SugarRecordDemo/SugarRecordTests/SugarRecordTests.swift
+++ b/SugarRecordDemo/SugarRecordTests/SugarRecordTests.swift
@@ -92,7 +92,7 @@ class SugarRecordOperationsTests: QuickSpec {
             
             it ("should save successfully") {
                 var saved = false
-                SugarRecord.save(inBackground: true, savingBlock: { (context) -> () in
+                SugarRecord.save(inBackground: true, savingClosure: { (context) -> () in
                     let fran: Person = Person.create(inContext: context) as Person
                     fran.name = "Fran"
                     fran.age = "27"
@@ -107,7 +107,7 @@ class SugarRecordOperationsTests: QuickSpec {
             
             it ("should save on a background thread and completion clousure called in the mainThread") {
                 var saved = false
-                SugarRecord.save(inBackground: true, savingBlock: { (context) -> () in
+                SugarRecord.save(inBackground: true, savingClosure: { (context) -> () in
                     expect(NSThread.currentThread()).toNot(equal(NSThread.mainThread()));
                     }) { (success, error) -> () in
                     expect(NSThread.currentThread()).to(equal(NSThread.mainThread()));


### PR DESCRIPTION
## What? Why?

In Swift blocks are treated as Closures instead
## What should be tested?

Everything works and tests are passing after the renaming
## Related tasks?

**Related issue** https://github.com/SugarRecord/SugarRecord/issues/11

![image](http://media.giphy.com/media/fdiWBMyTEAhjy/giphy.gif)
