### PR TITLE
Added optional unwrapping which caused compilation error

### DIFF
--- a/library/CoreData/iCloudCDStack.swift
+++ b/library/CoreData/iCloudCDStack.swift
@@ -264,7 +264,7 @@ public class iCloudCDStack: DefaultCDStack
                 
                 /// Getting the database path
                 /// iCloudPath + iCloudDataPath + DatabaseName
-                self!.databasePath = NSURL(fileURLWithPath: iCloudRootPath!.path!.stringByAppendingPathComponent(self!.icloudData!.iCloudDataDirectoryName).stringByAppendingPathComponent(self!.databasePath!.lastPathComponent))
+                self!.databasePath = NSURL(fileURLWithPath: iCloudRootPath!.path!.stringByAppendingPathComponent(self!.icloudData!.iCloudDataDirectoryName).stringByAppendingPathComponent(self!.databasePath!.lastPathComponent!))
                 
                 // Adding store
                 self!.persistentStoreCoordinator!.lock()


### PR DESCRIPTION
I found compilation error on Xcode 6.1.1 for SRCoreData target due to not unwrapped optional in iCloud database creation part.
