### PR TITLE
Adding an example project

### DIFF
--- a/example/SugarRecordExample.xcodeproj/project.pbxproj
+++ b/example/SugarRecordExample.xcodeproj/project.pbxproj
@@ -1,0 +1,448 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E1526DAA1A3899D700BC6E1E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DA91A3899D700BC6E1E /* AppDelegate.swift */; };
+		E1526DAF1A3899D700BC6E1E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1526DAD1A3899D700BC6E1E /* Main.storyboard */; };
+		E1526DB11A3899D700BC6E1E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1526DB01A3899D700BC6E1E /* Images.xcassets */; };
+		E1526DB41A3899D700BC6E1E /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1526DB21A3899D700BC6E1E /* LaunchScreen.xib */; };
+		E1526DCA1A389A8000BC6E1E /* StacksTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DC91A389A8000BC6E1E /* StacksTableViewController.swift */; };
+		E1526DCC1A389B9C00BC6E1E /* CoreDataTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DCB1A389B9C00BC6E1E /* CoreDataTableViewController.swift */; };
+		E1526DD11A389F3200BC6E1E /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1526DD01A389F3200BC6E1E /* CoreData.framework */; };
+		E1526DEF1A38A05C00BC6E1E /* SugarRecordContextProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE01A38A05C00BC6E1E /* SugarRecordContextProtocol.swift */; };
+		E1526DF01A38A05C00BC6E1E /* SugarRecordObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE11A38A05C00BC6E1E /* SugarRecordObjectProtocol.swift */; };
+		E1526DF11A38A05C00BC6E1E /* SugarRecordStackProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE21A38A05C00BC6E1E /* SugarRecordStackProtocol.swift */; };
+		E1526DF21A38A05C00BC6E1E /* SugarRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE31A38A05C00BC6E1E /* SugarRecord.swift */; };
+		E1526DF31A38A05C00BC6E1E /* SugarRecordFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE41A38A05C00BC6E1E /* SugarRecordFinder.swift */; };
+		E1526DF41A38A05C00BC6E1E /* SugarRecordLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE51A38A05C00BC6E1E /* SugarRecordLogger.swift */; };
+		E1526DF51A38A05C00BC6E1E /* DefaultCDStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE81A38A05C00BC6E1E /* DefaultCDStack.swift */; };
+		E1526DF61A38A05C00BC6E1E /* iCloudCDStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DE91A38A05C00BC6E1E /* iCloudCDStack.swift */; };
+		E1526DF71A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DEA1A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift */; };
+		E1526DF81A38A05C00BC6E1E /* SugarRecordCDContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DEB1A38A05C00BC6E1E /* SugarRecordCDContext.swift */; };
+		E1526DF91A38A05C00BC6E1E /* SugarRecordFinder+FetchedResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DEC1A38A05C00BC6E1E /* SugarRecordFinder+FetchedResultsController.swift */; };
+		E1526DFC1A38A1DB00BC6E1E /* StackTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526DFB1A38A1DB00BC6E1E /* StackTableViewController.swift */; };
+		E1526DFF1A38A39600BC6E1E /* Models.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E1526DFD1A38A39600BC6E1E /* Models.xcdatamodeld */; };
+		E1526E021A38A51600BC6E1E /* CoreDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1526E011A38A51600BC6E1E /* CoreDataModel.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E1526DA41A3899D700BC6E1E /* SugarRecordExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SugarRecordExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1526DA81A3899D700BC6E1E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E1526DA91A3899D700BC6E1E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E1526DAE1A3899D700BC6E1E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E1526DB01A3899D700BC6E1E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		E1526DB31A3899D700BC6E1E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		E1526DC91A389A8000BC6E1E /* StacksTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StacksTableViewController.swift; sourceTree = "<group>"; };
+		E1526DCB1A389B9C00BC6E1E /* CoreDataTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataTableViewController.swift; sourceTree = "<group>"; };
+		E1526DD01A389F3200BC6E1E /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		E1526DE01A38A05C00BC6E1E /* SugarRecordContextProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordContextProtocol.swift; sourceTree = "<group>"; };
+		E1526DE11A38A05C00BC6E1E /* SugarRecordObjectProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordObjectProtocol.swift; sourceTree = "<group>"; };
+		E1526DE21A38A05C00BC6E1E /* SugarRecordStackProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordStackProtocol.swift; sourceTree = "<group>"; };
+		E1526DE31A38A05C00BC6E1E /* SugarRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecord.swift; sourceTree = "<group>"; };
+		E1526DE41A38A05C00BC6E1E /* SugarRecordFinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordFinder.swift; sourceTree = "<group>"; };
+		E1526DE51A38A05C00BC6E1E /* SugarRecordLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordLogger.swift; sourceTree = "<group>"; };
+		E1526DE81A38A05C00BC6E1E /* DefaultCDStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultCDStack.swift; sourceTree = "<group>"; };
+		E1526DE91A38A05C00BC6E1E /* iCloudCDStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iCloudCDStack.swift; sourceTree = "<group>"; };
+		E1526DEA1A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+SugarRecord.swift"; sourceTree = "<group>"; };
+		E1526DEB1A38A05C00BC6E1E /* SugarRecordCDContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SugarRecordCDContext.swift; sourceTree = "<group>"; };
+		E1526DEC1A38A05C00BC6E1E /* SugarRecordFinder+FetchedResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SugarRecordFinder+FetchedResultsController.swift"; sourceTree = "<group>"; };
+		E1526DEE1A38A05C00BC6E1E /* RestkitCDStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestkitCDStack.swift; sourceTree = "<group>"; };
+		E1526DFB1A38A1DB00BC6E1E /* StackTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StackTableViewController.swift; sourceTree = "<group>"; };
+		E1526DFE1A38A39600BC6E1E /* Models.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Models.xcdatamodel; sourceTree = "<group>"; };
+		E1526E011A38A51600BC6E1E /* CoreDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataModel.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E1526DA11A3899D700BC6E1E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1526DD11A389F3200BC6E1E /* CoreData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E1526D9B1A3899D700BC6E1E = {
+			isa = PBXGroup;
+			children = (
+				E1526DA61A3899D700BC6E1E /* SugarRecordExample */,
+				E1526DA51A3899D700BC6E1E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E1526DA51A3899D700BC6E1E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DA41A3899D700BC6E1E /* SugarRecordExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E1526DA61A3899D700BC6E1E /* SugarRecordExample */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DA91A3899D700BC6E1E /* AppDelegate.swift */,
+				E1526DC91A389A8000BC6E1E /* StacksTableViewController.swift */,
+				E1526DCD1A389CA400BC6E1E /* Stacks */,
+				E1526DCF1A389DC600BC6E1E /* SugarRecord */,
+				E1526DCE1A389CAB00BC6E1E /* Resources */,
+				E1526DA71A3899D700BC6E1E /* Supporting Files */,
+			);
+			path = SugarRecordExample;
+			sourceTree = "<group>";
+		};
+		E1526DA71A3899D700BC6E1E /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DD01A389F3200BC6E1E /* CoreData.framework */,
+				E1526DA81A3899D700BC6E1E /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E1526DCD1A389CA400BC6E1E /* Stacks */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DFB1A38A1DB00BC6E1E /* StackTableViewController.swift */,
+				E1526DFD1A38A39600BC6E1E /* Models.xcdatamodeld */,
+				E1526E001A38A4E100BC6E1E /* CoreData */,
+			);
+			name = Stacks;
+			sourceTree = "<group>";
+		};
+		E1526DCE1A389CAB00BC6E1E /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DB01A3899D700BC6E1E /* Images.xcassets */,
+				E1526DAD1A3899D700BC6E1E /* Main.storyboard */,
+				E1526DB21A3899D700BC6E1E /* LaunchScreen.xib */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		E1526DCF1A389DC600BC6E1E /* SugarRecord */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DDE1A38A05C00BC6E1E /* Core */,
+				E1526DE61A38A05C00BC6E1E /* CoreData */,
+			);
+			name = SugarRecord;
+			sourceTree = "<group>";
+		};
+		E1526DDE1A38A05C00BC6E1E /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DDF1A38A05C00BC6E1E /* Protocols */,
+				E1526DE31A38A05C00BC6E1E /* SugarRecord.swift */,
+				E1526DE41A38A05C00BC6E1E /* SugarRecordFinder.swift */,
+				E1526DE51A38A05C00BC6E1E /* SugarRecordLogger.swift */,
+			);
+			name = Core;
+			path = ../../library/Core;
+			sourceTree = "<group>";
+		};
+		E1526DDF1A38A05C00BC6E1E /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DE01A38A05C00BC6E1E /* SugarRecordContextProtocol.swift */,
+				E1526DE11A38A05C00BC6E1E /* SugarRecordObjectProtocol.swift */,
+				E1526DE21A38A05C00BC6E1E /* SugarRecordStackProtocol.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		E1526DE61A38A05C00BC6E1E /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DE71A38A05C00BC6E1E /* Base */,
+				E1526DED1A38A05C00BC6E1E /* RestKit */,
+			);
+			name = CoreData;
+			path = ../../library/CoreData;
+			sourceTree = "<group>";
+		};
+		E1526DE71A38A05C00BC6E1E /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DE81A38A05C00BC6E1E /* DefaultCDStack.swift */,
+				E1526DE91A38A05C00BC6E1E /* iCloudCDStack.swift */,
+				E1526DEA1A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift */,
+				E1526DEB1A38A05C00BC6E1E /* SugarRecordCDContext.swift */,
+				E1526DEC1A38A05C00BC6E1E /* SugarRecordFinder+FetchedResultsController.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		E1526DED1A38A05C00BC6E1E /* RestKit */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DEE1A38A05C00BC6E1E /* RestkitCDStack.swift */,
+			);
+			path = RestKit;
+			sourceTree = "<group>";
+		};
+		E1526E001A38A4E100BC6E1E /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				E1526DCB1A389B9C00BC6E1E /* CoreDataTableViewController.swift */,
+				E1526E011A38A51600BC6E1E /* CoreDataModel.swift */,
+			);
+			name = CoreData;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E1526DA31A3899D700BC6E1E /* SugarRecordExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1526DC31A3899D800BC6E1E /* Build configuration list for PBXNativeTarget "SugarRecordExample" */;
+			buildPhases = (
+				E1526DA01A3899D700BC6E1E /* Sources */,
+				E1526DA11A3899D700BC6E1E /* Frameworks */,
+				E1526DA21A3899D700BC6E1E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SugarRecordExample;
+			productName = SugarRecordExample;
+			productReference = E1526DA41A3899D700BC6E1E /* SugarRecordExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E1526D9C1A3899D700BC6E1E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = "Robert Dougan";
+				TargetAttributes = {
+					E1526DA31A3899D700BC6E1E = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = E1526D9F1A3899D700BC6E1E /* Build configuration list for PBXProject "SugarRecordExample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E1526D9B1A3899D700BC6E1E;
+			productRefGroup = E1526DA51A3899D700BC6E1E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E1526DA31A3899D700BC6E1E /* SugarRecordExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E1526DA21A3899D700BC6E1E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1526DAF1A3899D700BC6E1E /* Main.storyboard in Resources */,
+				E1526DB41A3899D700BC6E1E /* LaunchScreen.xib in Resources */,
+				E1526DB11A3899D700BC6E1E /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E1526DA01A3899D700BC6E1E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1526DAA1A3899D700BC6E1E /* AppDelegate.swift in Sources */,
+				E1526DFC1A38A1DB00BC6E1E /* StackTableViewController.swift in Sources */,
+				E1526DCC1A389B9C00BC6E1E /* CoreDataTableViewController.swift in Sources */,
+				E1526E021A38A51600BC6E1E /* CoreDataModel.swift in Sources */,
+				E1526DF21A38A05C00BC6E1E /* SugarRecord.swift in Sources */,
+				E1526DF31A38A05C00BC6E1E /* SugarRecordFinder.swift in Sources */,
+				E1526DF61A38A05C00BC6E1E /* iCloudCDStack.swift in Sources */,
+				E1526DF81A38A05C00BC6E1E /* SugarRecordCDContext.swift in Sources */,
+				E1526DF11A38A05C00BC6E1E /* SugarRecordStackProtocol.swift in Sources */,
+				E1526DF51A38A05C00BC6E1E /* DefaultCDStack.swift in Sources */,
+				E1526DF41A38A05C00BC6E1E /* SugarRecordLogger.swift in Sources */,
+				E1526DEF1A38A05C00BC6E1E /* SugarRecordContextProtocol.swift in Sources */,
+				E1526DFF1A38A39600BC6E1E /* Models.xcdatamodeld in Sources */,
+				E1526DF91A38A05C00BC6E1E /* SugarRecordFinder+FetchedResultsController.swift in Sources */,
+				E1526DCA1A389A8000BC6E1E /* StacksTableViewController.swift in Sources */,
+				E1526DF01A38A05C00BC6E1E /* SugarRecordObjectProtocol.swift in Sources */,
+				E1526DF71A38A05C00BC6E1E /* NSManagedObject+SugarRecord.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		E1526DAD1A3899D700BC6E1E /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E1526DAE1A3899D700BC6E1E /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E1526DB21A3899D700BC6E1E /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E1526DB31A3899D700BC6E1E /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E1526DC11A3899D800BC6E1E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E1526DC21A3899D800BC6E1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E1526DC41A3899D800BC6E1E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = SugarRecordExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E1526DC51A3899D800BC6E1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = SugarRecordExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E1526D9F1A3899D700BC6E1E /* Build configuration list for PBXProject "SugarRecordExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1526DC11A3899D800BC6E1E /* Debug */,
+				E1526DC21A3899D800BC6E1E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E1526DC31A3899D800BC6E1E /* Build configuration list for PBXNativeTarget "SugarRecordExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1526DC41A3899D800BC6E1E /* Debug */,
+				E1526DC51A3899D800BC6E1E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		E1526DFD1A38A39600BC6E1E /* Models.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E1526DFE1A38A39600BC6E1E /* Models.xcdatamodel */,
+			);
+			currentVersion = E1526DFE1A38A39600BC6E1E /* Models.xcdatamodel */;
+			path = Models.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = E1526D9C1A3899D700BC6E1E /* Project object */;
+}

--- a/example/SugarRecordExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/SugarRecordExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SugarRecordExample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/example/SugarRecordExample/AppDelegate.swift
+++ b/example/SugarRecordExample/AppDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  AppDelegate.swift
+//  SugarRecordExample
+//
+//  Created by Robert Dougan on 10/12/14.
+//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        return true
+    }
+
+    // The following 3 methods are VERY important. If not added, your data will not be stored when your app is closed.
+    
+    func applicationWillResignActive(application: UIApplication) {
+        SugarRecord.applicationWillResignActive()
+    }
+    
+    func applicationWillEnterForeground(application: UIApplication) {
+        SugarRecord.applicationWillEnterForeground()
+    }
+    
+    func applicationWillTerminate(application: UIApplication) {
+        SugarRecord.applicationWillTerminate()
+    }
+
+}
+

--- a/example/SugarRecordExample/Base.lproj/LaunchScreen.xib
+++ b/example/SugarRecordExample/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 Robert Dougan. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SugarRecordExample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/example/SugarRecordExample/Base.lproj/Main.storyboard
+++ b/example/SugarRecordExample/Base.lproj/Main.storyboard
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M9n-eZ-gNF">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+    </dependencies>
+    <scenes>
+        <!--Sugar Record-->
+        <scene sceneID="VXO-rW-7Ls">
+            <objects>
+                <tableViewController id="Eu1-X8-E0e" customClass="StacksTableViewController" customModule="SugarRecordExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="kWx-k0-JsZ">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="StackCell" id="EFT-XC-5uz">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="EFT-XC-5uz" id="tjD-Pf-2tl">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="Eu1-X8-E0e" id="pyV-b2-KoB"/>
+                            <outlet property="delegate" destination="Eu1-X8-E0e" id="SHw-Rl-HPv"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Sugar Record" id="azx-H4-aA4"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Q1h-H6-zjP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="207" y="1067"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="0NB-L6-J9t">
+            <objects>
+                <navigationController id="M9n-eZ-gNF" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="eHc-aJ-CFf">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="Eu1-X8-E0e" kind="relationship" relationship="rootViewController" id="9Vp-q0-C9x"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GdE-1i-3xY" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-613" y="1067"/>
+        </scene>
+    </scenes>
+</document>

--- a/example/SugarRecordExample/CoreDataModel.swift
+++ b/example/SugarRecordExample/CoreDataModel.swift
@@ -1,0 +1,17 @@
+//
+//  CoreDataModel.swift
+//  SugarRecordExample
+//
+//  Created by Robert Dougan on 10/12/14.
+//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+@objc(CoreDataModel)
+class CoreDataModel: NSManagedObject {
+
+    @NSManaged var text: String
+
+}

--- a/example/SugarRecordExample/CoreDataTableViewController.swift
+++ b/example/SugarRecordExample/CoreDataTableViewController.swift
@@ -1,0 +1,24 @@
+//
+//  CoreDataTableViewController.swift
+//  SugarRecordExample
+//
+//  Created by Robert Dougan on 10/12/14.
+//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//
+
+import UIKit
+import CoreData
+
+class CoreDataTableViewController: StackTableViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.title = "Core Data"
+        
+        self.stack = DefaultCDStack(databaseName: "CoreData.sqlite", model: self.model, automigrating: true)
+        SugarRecord.addStack(self.stack!)
+        
+        self.entityClass = CoreDataModel.self
+    }
+}

--- a/example/SugarRecordExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/example/SugarRecordExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/example/SugarRecordExample/Info.plist
+++ b/example/SugarRecordExample/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.sugarrecord.example.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/example/SugarRecordExample/Models.xcdatamodeld/Models.xcdatamodel/contents
+++ b/example/SugarRecordExample/Models.xcdatamodeld/Models.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14B25" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="CoreDataModel" representedClassName="CoreDataModel" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="CoreDataModel" positionX="-63" positionY="-18" width="128" height="60"/>
+    </elements>
+</model>

--- a/example/SugarRecordExample/StackTableViewController.swift
+++ b/example/SugarRecordExample/StackTableViewController.swift
@@ -1,0 +1,95 @@
+//
+//  StackTableViewController.swift
+//  SugarRecordExample
+//
+//  Created by Robert Dougan on 10/12/14.
+//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//
+
+import UIKit
+import CoreData
+
+class StackTableViewController: UITableViewController {
+    
+    var stack: SugarRecordStackProtocol?
+    var data: [NSManagedObject]?
+    
+    let model: NSManagedObjectModel = {
+        let modelPath: NSString = NSBundle.mainBundle().pathForResource("Models", ofType: "momd")!
+        let model: NSManagedObjectModel = NSManagedObjectModel(contentsOfURL: NSURL(fileURLWithPath: modelPath)!)!
+        return model
+    }()
+    
+    var entityClass: NSManagedObject.Type = NSManagedObject.self
+    
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        self.tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "ModelCell")
+        
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: "add:")
+        
+        super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.fetchData()
+        self.tableView.reloadData()
+    }
+    
+    // MARK: - StackTableViewController
+    
+    @IBAction func add(sender: AnyObject?) {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "MMMM d yyyy - HH:mm:ss"
+        
+        let model = self.entityClass.create() as CoreDataModel
+        model.text = formatter.stringFromDate(NSDate())
+        model.save()
+        
+        self.fetchData()
+        
+        let indexPath = NSIndexPath(forRow: 0, inSection: 0)
+        tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Top)
+    }
+    
+    func fetchData() {
+        self.data = self.entityClass.all().sorted(by: "text", ascending: false).find()! as? [NSManagedObject]
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return (self.data == nil) ? 0 : self.data!.count
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier("ModelCell", forIndexPath: indexPath) as UITableViewCell
+
+        let model = self.data![indexPath.row] as CoreDataModel
+        cell.textLabel?.text = model.text
+
+        return cell
+    }
+
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        if (editingStyle == .Delete) {
+            let model = self.data![indexPath.row] as CoreDataModel
+            model.beginWriting().delete().endWriting()
+            
+            self.fetchData()
+            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
+        }
+    }
+    
+}

--- a/example/SugarRecordExample/StacksTableViewController.swift
+++ b/example/SugarRecordExample/StacksTableViewController.swift
@@ -1,0 +1,56 @@
+//
+//  StacksTableViewController.swift
+//  SugarRecordExample
+//
+//  Created by Robert Dougan on 10/12/14.
+//  Copyright (c) 2014 Robert Dougan. All rights reserved.
+//
+
+import UIKit
+
+class StacksTableViewController: UITableViewController {
+    
+    var stacks: [String] = [
+        "CoreData"
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.stacks.count
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier("StackCell", forIndexPath: indexPath) as UITableViewCell
+
+        cell.textLabel?.text = self.stacks[indexPath.row]
+
+        return cell
+    }
+    
+    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        var viewController: UITableViewController?
+        let stack = self.stacks[indexPath.row]
+        
+        switch (stack) {
+        case "CoreData":
+            viewController = CoreDataTableViewController()
+            
+        default:
+            println("View Controller not found for stack: \(stack)")
+        }
+        
+        if (viewController != nil) {
+            self.navigationController!.pushViewController(viewController!, animated: true)
+        }
+    }
+
+}


### PR DESCRIPTION
Issue reference: #69 
- Added an example project
- Linked SugarRecord
- Added `StacksTableViewController` which displays all the Stack types. Right now I've only added CoreData.
- Added `StackTableViewController` as a based TableViewController to be used for each stack. In a subclass, you can just create the stack and define the `entityClass`, and you are good to go. Adding and deleting is supported right now.

Thoughts:
- Can all the Entity Classes share one NSManagedObject subclass, or is that not possible? I have not looked at the other stacks yet, but I do not believe so. Right now I have one created for CoreData, but if we have to make multiple we should make a simple protocol so they all have the same properties.
