### PR TITLE
[WIP] Migrate SugarRecord syntax to be Swift3 compatible

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "ReactiveCocoa/ReactiveCocoa" "v4.2.0"
 github "realm/realm-cocoa" "v1.0.1"
-github "ReactiveX/RxSwift" "2.5.0"
+github "ReactiveX/RxSwift" "swift-3.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.2"
-github "antitypical/Result" "2.1.1"
-github "ReactiveX/RxSwift" "2.5.0"
+github "antitypical/Result" "2.1.2"
+github "ReactiveX/RxSwift" "cba021a9614628a514a39c234d72686e4a393e63"
 github "realm/realm-cocoa" "v1.0.1"
 github "ReactiveCocoa/ReactiveCocoa" "v4.2.0"

--- a/SugarRecord.xcodeproj/project.pbxproj
+++ b/SugarRecord.xcodeproj/project.pbxproj
@@ -1411,9 +1411,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = GitDo;
 				TargetAttributes = {
+					2319B8831C2402490050ABE8 = {
+						LastSwiftMigration = 0800;
+					};
 					3DB2B82C1BDEE187005B7EF2 = {
 						CreatedOnToolsVersion = 7.1;
 					};
@@ -2131,6 +2134,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-watchOS";
 				PRODUCT_NAME = SugarRecordRealm;
 				SDKROOT = watchos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.1;
 			};
@@ -2184,6 +2188,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-tvOS";
 				PRODUCT_NAME = SugarRecordRealm;
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -2241,6 +2246,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-OSX";
 				PRODUCT_NAME = SugarRecordRealm;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -2248,13 +2254,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB2B8A61BDEE795005B7EF2 /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2268,6 +2274,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-iOS";
 				PRODUCT_NAME = SugarRecordRealm;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2275,13 +2282,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB2B8A61BDEE795005B7EF2 /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2294,6 +2301,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-iOS";
 				PRODUCT_NAME = SugarRecordRealm;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2440,6 +2449,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-watchOS";
 				PRODUCT_NAME = SugarRecordCoreData;
 				SDKROOT = watchos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.1;
 			};
@@ -2493,6 +2503,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-tvOS";
 				PRODUCT_NAME = SugarRecordCoreData;
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -2550,6 +2561,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-OSX";
 				PRODUCT_NAME = SugarRecordCoreData;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -2557,13 +2569,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB2B8A61BDEE795005B7EF2 /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2583,13 +2595,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3DB2B8A61BDEE795005B7EF2 /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2601,6 +2613,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.gitdo.SugarRecord-iOS";
 				PRODUCT_NAME = SugarRecordCoreData;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -2626,6 +2639,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.gitdo.SugarRecordTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-OSX.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-iOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-tvOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-watchOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-CoreData-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-OSX.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-iOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-tvOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-watchOS.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecord-Realm-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecordTests.xcscheme
+++ b/SugarRecord.xcodeproj/xcshareddata/xcschemes/SugarRecordTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SugarRecord/Source/Foundation/Entities/Request.swift
+++ b/SugarRecord/Source/Foundation/Entities/Request.swift
@@ -4,14 +4,14 @@ public struct Request<T: Entity>: Equatable {
     
     // MARK: - Attributes
     
-    public let sortDescriptor: NSSortDescriptor?
-    public let predicate: NSPredicate?
+    public let sortDescriptor: SortDescriptor?
+    public let predicate: Predicate?
     let context: Context?
     
     
     // MARK: - Init
     
-    public init(_ requestable: Requestable? = nil, sortDescriptor: NSSortDescriptor? = nil, predicate: NSPredicate? = nil) {
+    public init(_ requestable: Requestable? = nil, sortDescriptor: SortDescriptor? = nil, predicate: Predicate? = nil) {
         self.context = requestable?.requestContext()
         self.sortDescriptor = sortDescriptor
         self.predicate = predicate
@@ -24,51 +24,51 @@ public struct Request<T: Entity>: Equatable {
         return try context!.fetch(self)
     }
     
-    public func fetch(requestable: Requestable) throws -> [T] {
+    public func fetch(_ requestable: Requestable) throws -> [T] {
         return try requestable.requestContext().fetch(self)
     }
     
     
     // MARK: - Public Builder Methods
     
-    public func filteredWith(predicate predicate: NSPredicate) -> Request<T> {
+    public func filteredWith(predicate: Predicate) -> Request<T> {
         return self
             .request(withPredicate: predicate)
     }
     
-    public func filteredWith(key: String, equalTo value: String) -> Request<T> {
+    public func filteredWith(_ key: String, equalTo value: String) -> Request<T> {
         return self
-            .request(withPredicate: NSPredicate(format: "\(key) == %@", value))
+            .request(withPredicate: Predicate(format: "\(key) == %@", value))
     }
     
-    public func sortedWith(sortDescriptor sortDescriptor: NSSortDescriptor) -> Request<T> {
+    public func sortedWith(sortDescriptor: SortDescriptor) -> Request<T> {
         return self
             .request(withSortDescriptor: sortDescriptor)
     }
     
-    public func sortedWith(key: String?, ascending: Bool, comparator cmptr: NSComparator) -> Request<T> {
+    public func sortedWith(_ key: String?, ascending: Bool, comparator cmptr: Comparator) -> Request<T> {
         return self
-            .request(withSortDescriptor: NSSortDescriptor(key: key, ascending: ascending, comparator: cmptr))
+            .request(withSortDescriptor: SortDescriptor(key: key, ascending: ascending, comparator: cmptr))
     }
     
-    public func sortedWith(key: String?, ascending: Bool) -> Request<T> {
+    public func sortedWith(_ key: String?, ascending: Bool) -> Request<T> {
         return self
-            .request(withSortDescriptor: NSSortDescriptor(key: key, ascending: ascending))
+            .request(withSortDescriptor: SortDescriptor(key: key, ascending: ascending))
     }
     
-    public func sortedWith(key: String?, ascending: Bool, selector: Selector) -> Request<T> {
+    public func sortedWith(_ key: String?, ascending: Bool, selector: Selector) -> Request<T> {
         return self
-            .request(withSortDescriptor: NSSortDescriptor(key: key, ascending: ascending, selector: selector))
+            .request(withSortDescriptor: SortDescriptor(key: key, ascending: ascending, selector: selector))
     }
     
     
     // MARK: - Internal
     
-    func request(withPredicate predicate: NSPredicate) -> Request<T> {
+    func request(withPredicate predicate: Predicate) -> Request<T> {
         return Request<T>(context, sortDescriptor: sortDescriptor, predicate: predicate)
     }
     
-    func request(withSortDescriptor sortDescriptor: NSSortDescriptor) -> Request<T> {
+    func request(withSortDescriptor sortDescriptor: SortDescriptor) -> Request<T> {
         return Request<T>(context, sortDescriptor: sortDescriptor, predicate: predicate)
     }
     

--- a/SugarRecord/Source/Foundation/Entities/RequestObservable.swift
+++ b/SugarRecord/Source/Foundation/Entities/RequestObservable.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum ObservableChange<T> {
-    case Initial([T])
-    case Update(deletions: [Int], insertions: [(index: Int, element: T)], modifications: [(index: Int, element: T)])
-    case Error(NSError)
+    case initial([T])
+    case update(deletions: [Int], insertions: [(index: Int, element: T)], modifications: [(index: Int, element: T)])
+    case error(NSError)
 }
 
 public class RequestObservable<T: Entity>: NSObject {
@@ -22,7 +22,7 @@ public class RequestObservable<T: Entity>: NSObject {
     
     // MARK: - Public
     
-    public func observe(closure: ObservableChange<T> -> Void) {
+    public func observe(_ closure: (ObservableChange<T>) -> Void) {
         assertionFailure("The observe method must be overriden")
     }
     

--- a/SugarRecord/Source/Foundation/Entities/Storage.swift
+++ b/SugarRecord/Source/Foundation/Entities/Storage.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum StorageType {
-    case CoreData
-    case Realm
+    case coreData
+    case realm
 }
 
 typealias StorageOperation = ((context: Context, save: () -> Void) throws -> Void) throws -> Void
@@ -14,8 +14,8 @@ public protocol Storage: CustomStringConvertible, Requestable {
     var saveContext: Context! { get }
     var memoryContext: Context! { get }
     func removeStore() throws
-    func operation<T>(operation: (context: Context, save: () -> Void) throws -> T) throws -> T
-    func fetch<T: Entity>(request: Request<T>) throws -> [T]
+    func operation<T>(_ operation: (context: Context, save: () -> Void) throws -> T) throws -> T
+    func fetch<T: Entity>(_ request: Request<T>) throws -> [T]
     
 }
 
@@ -23,7 +23,7 @@ public protocol Storage: CustomStringConvertible, Requestable {
 
 public extension Storage {
 
-    func fetch<T: Entity>(request: Request<T>) throws -> [T] {
+    func fetch<T: Entity>(_ request: Request<T>) throws -> [T] {
         return try self.mainContext.fetch(request)
     }
     

--- a/SugarRecord/Source/Foundation/Errors/Error.swift
+++ b/SugarRecord/Source/Foundation/Errors/Error.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public enum Error: ErrorType {
-    case WriteError
-    case InvalidType
-    case FetchError(ErrorType)
-    case Store(ErrorType)
-    case InvalidOperation(String)
-    case Unknown
+public enum Error: ErrorProtocol {
+    case writeError
+    case invalidType
+    case fetchError(ErrorProtocol)
+    case store(ErrorProtocol)
+    case invalidOperation(String)
+    case unknown
 }

--- a/SugarRecord/Source/Foundation/Extensions/RequestExtension.swift
+++ b/SugarRecord/Source/Foundation/Extensions/RequestExtension.swift
@@ -5,7 +5,7 @@ import Foundation
 
 extension Request: NSPredicateConvertible {
     
-    public init(predicate: NSPredicate) {
+    public init(predicate: Predicate) {
         self = Request(predicate: predicate)
     }
 }
@@ -15,7 +15,7 @@ extension Request: NSPredicateConvertible {
 
 extension Request: NSSortDescriptorConvertible {
     
-    public init(sortDescriptor: NSSortDescriptor) {
+    public init(sortDescriptor: SortDescriptor) {
         self = Request(sortDescriptor: sortDescriptor)
     }
 

--- a/SugarRecord/Source/Foundation/Logger/Logger.swift
+++ b/SugarRecord/Source/Foundation/Logger/Logger.swift
@@ -4,7 +4,7 @@ internal class Logger {
     
     // MARK: - Internal
     
-    internal func log(message: String) {
+    internal func log(_ message: String) {
         print("🍬 SugarRecord: \(message)")
     }
     

--- a/SugarRecord/Source/Foundation/Protocols/Context.swift
+++ b/SugarRecord/Source/Foundation/Protocols/Context.swift
@@ -2,12 +2,12 @@ import Foundation
 
 public protocol Context: Requestable {
     
-    func fetch<T: Entity>(request: Request<T>) throws -> [T]
-    func insert<T: Entity>(entity: T) throws
+    func fetch<T: Entity>(_ request: Request<T>) throws -> [T]
+    func insert<T: Entity>(_ entity: T) throws
     func new<T: Entity>() throws -> T
     func create<T: Entity>() throws -> T
-    func remove<T: Entity>(objects: [T]) throws
-    func remove<T: Entity>(object: T) throws
+    func remove<T: Entity>(_ objects: [T]) throws
+    func remove<T: Entity>(_ object: T) throws
     func removeAll() throws
 }
 
@@ -22,7 +22,7 @@ public extension Context {
         return instance
     }
 
-    public func remove<T: Entity>(object: T) throws {
+    public func remove<T: Entity>(_ object: T) throws {
         return try self.remove([object])
     }
     

--- a/SugarRecord/Source/Foundation/Protocols/NSPredicateConvertible.swift
+++ b/SugarRecord/Source/Foundation/Protocols/NSPredicateConvertible.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol NSPredicateConvertible {
     
-    init(predicate: NSPredicate)    
-    var predicate: NSPredicate? { get }
+    init(predicate: Predicate)    
+    var predicate: Predicate? { get }
 
 }

--- a/SugarRecord/Source/Foundation/Protocols/NSSortDescriptorConvertible.swift
+++ b/SugarRecord/Source/Foundation/Protocols/NSSortDescriptorConvertible.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol NSSortDescriptorConvertible {
     
-    init(sortDescriptor: NSSortDescriptor)    
-    var sortDescriptor: NSSortDescriptor? { get }
+    init(sortDescriptor: SortDescriptor)    
+    var sortDescriptor: SortDescriptor? { get }
 
 }

--- a/SugarRecord/Source/Foundation/Protocols/Requestable.swift
+++ b/SugarRecord/Source/Foundation/Protocols/Requestable.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol Requestable {
     
     func requestContext() -> Context
-    func request<T>(model: T.Type) -> Request<T>
+    func request<T>(_ model: T.Type) -> Request<T>
     
 }
 
@@ -13,7 +13,7 @@ public extension Requestable where Self: Context {
         return self
     }
     
-    func request<T>(model: T.Type) -> Request<T> {
+    func request<T>(_ model: T.Type) -> Request<T> {
         return Request<T>(self)
     }
 
@@ -25,7 +25,7 @@ public extension Requestable where Self:Storage {
         return self.mainContext
     }
     
-    func request<T>(model: T.Type) -> Request<T> {
+    func request<T>(_ model: T.Type) -> Request<T> {
         return Request<T>(self.mainContext)
     }
     

--- a/SugarRecord/Source/Foundation/Utils/DirUtils.swift
+++ b/SugarRecord/Source/Foundation/Utils/DirUtils.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 func documentsDirectory() -> String {
-    let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)
+    let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
     return paths[0]
 }

--- a/SugarRecord/Source/Foundation/Version/VersionProvider.swift
+++ b/SugarRecord/Source/Foundation/Version/VersionProvider.swift
@@ -10,17 +10,19 @@ internal class VersionProvider: NSObject {
     // MARK: - Internal
     
     internal func framework() -> String! {
-        if let version = NSBundle(forClass: VersionProvider.classForCoder()).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
+        if let version = Bundle(for: VersionProvider.classForCoder()).objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
             return version
         }
         return nil
     }
     
-    internal func github(completion: String -> Void) {
-        let request: NSURLRequest = NSURLRequest(URL: NSURL(string: VersionProvider.apiReleasesUrl)!)
-        NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration()).dataTaskWithRequest(request, completionHandler: { (data, response, error) in
+    internal func github(completion: (String) -> Void) {
+        
+        
+        let request: URLRequest = URLRequest(url: URL(string: VersionProvider.apiReleasesUrl)!)
+        URLSession(configuration: URLSessionConfiguration.default()).dataTask(with: request, completionHandler: { (data, response, error) in
             if let data = data {
-                let json: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments)
+                let json: AnyObject? = try? JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
                 if let array = json as? [[String: AnyObject]], lastVersion = array.first, versionTag: String = lastVersion["tag_name"] as? String {
                     completion(versionTag)
                 }

--- a/SugarRecord/Source/Reactive/ReactiveError.swift
+++ b/SugarRecord/Source/Reactive/ReactiveError.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public enum ReactiveError: ErrorType {}
+public enum ReactiveError: ErrorProtocol {}

--- a/SugarRecord/Source/Reactive/Rx/ReactiveStorage+Rx.swift
+++ b/SugarRecord/Source/Reactive/Rx/ReactiveStorage+Rx.swift
@@ -3,7 +3,7 @@ import RxSwift
 
 public extension Storage {
 
-    func rx_operation<T>(op: (context: Context, save: () -> Void) throws -> T) -> Observable<T> {
+    func rx_operation<T>(_ op: (context: Context, save: () -> Void) throws -> T) -> Observable<T> {
         return Observable.create { (observer) -> Disposable in
             do {
                 let returnedObject = try self.operation { (context, saver) throws -> T in
@@ -22,7 +22,7 @@ public extension Storage {
         }
     }
     
-    func rx_operation<T>(op: (context: Context) throws -> T) -> Observable<T> {
+    func rx_operation<T>(_ op: (context: Context) throws -> T) -> Observable<T> {
         return rx_operation { (context, save) in
             
             let returnedObject = try op(context: context)
@@ -32,7 +32,7 @@ public extension Storage {
         }
     }
     
-    func rx_backgroundOperation<T>(op: (context: Context, save: () -> Void) throws -> T) -> Observable<T> {
+    func rx_backgroundOperation<T>(_ op: (context: Context, save: () -> Void) throws -> T) -> Observable<T> {
         return Observable.create { (observer) -> Disposable in
             do {
                 let returnedObject = try self.operation { (context, saver) throws -> T in
@@ -52,7 +52,7 @@ public extension Storage {
         }
     }
     
-    func rx_backgroundOperation<T>(op: (context: Context) throws -> T) -> Observable<T> {
+    func rx_backgroundOperation<T>(_ op: (context: Context) throws -> T) -> Observable<T> {
         return rx_backgroundOperation { (context, save) throws in
             
             let returnedObject = try op(context: context)
@@ -62,10 +62,10 @@ public extension Storage {
         }
     }
     
-    func rx_backgroundFetch<T, U>(request: Request<T>, mapper: T -> U) -> Observable<[U]> {
+    func rx_backgroundFetch<T, U>(_ request: Request<T>, mapper: (T) -> U) -> Observable<[U]> {
         let observable: Observable<[T]> = Observable.create { (observer) -> Disposable in
-            let priority = DISPATCH_QUEUE_PRIORITY_DEFAULT
-            dispatch_async(dispatch_get_global_queue(priority, 0)) {
+            let priority = DispatchQueue.GlobalAttributes.qosDefault
+            DispatchQueue.global(attributes: priority).async {
                 do {
                     let results = try self.saveContext.fetch(request)
                     observer.onNext(results)
@@ -88,7 +88,7 @@ public extension Storage {
             .observeOn(MainScheduler.instance)
     }
 
-    func rx_fetch<T>(request: Request<T>) -> Observable<[T]> {
+    func rx_fetch<T>(_ request: Request<T>) -> Observable<[T]> {
         return Observable.create { (observer) -> Disposable in
             do {
                 try observer.onNext(self.fetch(request))

--- a/SugarRecord/Source/Realm/Entities/RealmObservable.swift
+++ b/SugarRecord/Source/Realm/Entities/RealmObservable.swift
@@ -19,7 +19,7 @@ public class RealmObservable<T: Object>: RequestObservable<T> {
     
     // MARK: - Observable
     
-    public override func observe(closure: ObservableChange<T> -> Void) {
+    public override func observe(_ closure: (ObservableChange<T>) -> Void) {
         assert(self.notificationToken == nil, "Observable can be observed only once")
         var realmObjects = self.realm.objects(T)
         if let predicate = self.request.predicate {
@@ -40,17 +40,17 @@ public class RealmObservable<T: Object>: RequestObservable<T> {
     
     // MARK: - Private
     
-    private func map(realmChange: RealmCollectionChange<Results<T>>) -> ObservableChange<T> {
+    private func map(_ realmChange: RealmCollectionChange<Results<T>>) -> ObservableChange<T> {
         switch realmChange {
-        case .Error(let error):
-            return ObservableChange.Error(error)
-        case .Initial(let initial):
-            return ObservableChange.Initial(initial.toArray())
-        case .Update(let objects, let deletions, let insertions, let modifications):
+        case .error(let error):
+            return ObservableChange.error(error)
+        case .initial(let initial):
+            return ObservableChange.initial(initial.toArray())
+        case .update(let objects, let deletions, let insertions, let modifications):
             let deletions = deletions.map { $0 }
             let insertions = insertions.map { (index: $0, element: objects[$0]) }
             let modifications = modifications.map { (index: $0, element: objects[$0]) }
-            return ObservableChange.Update(deletions: deletions, insertions: insertions, modifications: modifications)
+            return ObservableChange.update(deletions: deletions, insertions: insertions, modifications: modifications)
         }
     }
     

--- a/SugarRecord/Source/Realm/Extensions/Object.swift
+++ b/SugarRecord/Source/Realm/Extensions/Object.swift
@@ -1,4 +1,4 @@
 import Foundation
 import RealmSwift
 
-extension Object: Entity {}
+extension RealmSwift.Object: Entity {}

--- a/SugarRecord/Source/Realm/Extensions/Realm.swift
+++ b/SugarRecord/Source/Realm/Extensions/Realm.swift
@@ -3,8 +3,8 @@ import RealmSwift
 
 extension Realm: Context {
     
-    public func fetch<T: Entity>(request: Request<T>) throws -> [T] {
-        guard let entity = T.self as? Object.Type else { throw Error.InvalidType }
+    public func fetch<T: Entity>(_ request: Request<T>) throws -> [T] {
+        guard let entity = T.self as? RealmSwift.Object.Type else { throw Error.invalidType }
         var results = self.objects(entity.self)
         if let predicate = request.predicate {
             results = results.filter(predicate)
@@ -15,17 +15,17 @@ extension Realm: Context {
         return results.toArray().map { $0 as Any as! T }
     }
     
-    public func insert<T: Entity>(entity: T) throws {
-        guard let _ = T.self as? Object.Type else { throw Error.InvalidType }
-        self.add(entity as! Object, update: false)
+    public func insert<T: Entity>(_ entity: T) throws {
+        guard let _ = T.self as? RealmSwift.Object.Type else { throw Error.invalidType }
+        self.add(entity as! RealmSwift.Object, update: false)
     }
     
     public func new<T: Entity>() throws -> T {
-        guard let entity = T.self as? Object.Type else { throw Error.InvalidType }
+        guard let entity = T.self as? RealmSwift.Object.Type else { throw Error.invalidType }
         return entity.init() as! T
     }
     
-    public func remove<T: Entity>(objects: [T]) throws {
+    public func remove<T: Entity>(_ objects: [T]) throws {
         let objectsToDelete = objects
             .map { $0.realm }
             .filter { $0 != nil }

--- a/SugarRecord/Source/Realm/Extensions/RealmEntity.swift
+++ b/SugarRecord/Source/Realm/Extensions/RealmEntity.swift
@@ -4,9 +4,9 @@ import RealmSwift
 extension Entity {
     
     /// Realm object wrapped by the Entity
-    var realm: Object? {
+    var realm: RealmSwift.Object? {
         get {
-            return (self as? Object)
+            return (self as? RealmSwift.Object)
         }
     }
     

--- a/SugarRecord/Source/Realm/Storages/RealmDefaultStorage.swift
+++ b/SugarRecord/Source/Realm/Storages/RealmDefaultStorage.swift
@@ -24,7 +24,7 @@ public class RealmDefaultStorage: Storage {
     
     public var description: String { return "RealmDefaultStorage" }
     
-    public var type: StorageType { return .Realm }
+    public var type: StorageType { return .realm }
     
     public var mainContext: Context! {
         if let configuration = self.configuration {
@@ -50,15 +50,15 @@ public class RealmDefaultStorage: Storage {
     
     public func removeStore() throws {
         if let url = try Realm().configuration.fileURL {
-            try NSFileManager.defaultManager().removeItemAtURL(url)
+            try FileManager.default().removeItem(at: url)
         }
     }
 
-    public func operation<T>(operation: (context: Context, save: () -> Void) throws -> T) throws -> T {
+    public func operation<T>(_ operation: (context: Context, save: () -> Void) throws -> T) throws -> T {
         let context: Realm = self.saveContext as! Realm
         context.beginWrite()
         var save: Bool = false
-        var _error: ErrorType!
+        var _error: ErrorProtocol!
         
         var returnedObject: T!
         do {
@@ -89,7 +89,7 @@ public class RealmDefaultStorage: Storage {
 
     }
     
-    public func observable<T: Object>(request: Request<T>) -> RequestObservable<T> {
+    public func observable<T: RealmSwift.Object>(_ request: Request<T>) -> RequestObservable<T> {
         return RealmObservable(request: request, realm: self.mainContext as! Realm)
     }
     


### PR DESCRIPTION
The purpose of this PR is giving support to Swift3. Although I've migrated the syntax of the library, some dependencies has to be updated to the Swift3 version.

## ✅ TODO
- [x] SugarRecord ~> Swift3
- [ ] RxSwift ~> Swift3
- [ ] ReactiveCocoa ~> Swift3
- [ ] Quick ~> Swift3
- [ ] Nimble ~> Swift3

- [ ] Update Travis script.
- [ ] Update README

> This branch should be merged into master and the version bumped once the official version of Swift3 gets released.