### PR TITLE
Add -backgroundOperation to Storage

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.2"
-github "antitypical/Result" "2.1.1"
+github "antitypical/Result" "2.1.3"
 github "ReactiveX/RxSwift" "2.5.0"
 github "realm/realm-cocoa" "v1.0.1"
 github "ReactiveCocoa/ReactiveCocoa" "v4.2.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.2"
-github "antitypical/Result" "2.1.3"
+github "antitypical/Result" "2.1.1"
 github "ReactiveX/RxSwift" "2.5.0"
 github "realm/realm-cocoa" "v1.0.1"
 github "ReactiveCocoa/ReactiveCocoa" "v4.2.0"

--- a/SugarRecord/Source/Reactive/ReactiveCocoa/ReactiveStorage+ReactiveCocoa.swift
+++ b/SugarRecord/Source/Reactive/ReactiveCocoa/ReactiveStorage+ReactiveCocoa.swift
@@ -14,7 +14,6 @@ public extension Storage {
                         saver()
                     })
                 }
-                
                 observer.sendNext(returnedObject)
                 observer.sendCompleted()
             }
@@ -33,56 +32,25 @@ public extension Storage {
     }
     
     func rac_backgroundOperation<T>(op: (context: Context, save: () -> Void) throws -> T) -> SignalProducer<T, Error> {
-        return SignalProducer { (observer, disposable) in
-            let priority = DISPATCH_QUEUE_PRIORITY_DEFAULT
-            dispatch_async(dispatch_get_global_queue(priority, 0)) {
-                do {
-                    let returnedObject = try self.operation { (context, saver) throws in
-                        try op(context: context, save: {
-                            saver()
-                        })
-                    }
-                    observer.sendNext(returnedObject)
-                    observer.sendCompleted()
-                }
-                catch {
-                    observer.sendFailed(Error.Store(error))
-                }
-            }
-        }
+        return self.rac_operation(op)
+            .startOn(UIScheduler())
+            .observeOn(UIScheduler())
     }
     
     func rac_backgroundOperation<T>(op: (context: Context) throws -> T) -> SignalProducer<T, Error> {
         return rac_backgroundOperation { (context, save) throws in
             let returnedObject = try op(context: context)
             save()
-            
             return returnedObject
         }
     }
 
     
     func rac_backgroundFetch<T: Entity, U>(request: Request<T>, mapper: T -> U) -> SignalProducer<[U], Error> {
-        let producer: SignalProducer<[T], Error> = SignalProducer { (observer, disposable) in
-            let priority = DISPATCH_QUEUE_PRIORITY_DEFAULT
-            dispatch_async(dispatch_get_global_queue(priority, 0)) {
-                do {
-                    let results = try self.saveContext.fetch(request)
-                    observer.sendNext(results)
-                    observer.sendCompleted()
-                }
-                catch {
-                    if let error = error as? Error {
-                        observer.sendFailed(error)
-                    }
-                    else {
-                        observer.sendNext([])
-                        observer.sendCompleted()
-                    }
-                }
-            }
-        }
-        return producer.map { $0.map(mapper) }.observeOn(UIScheduler())
+        return rac_fetch(request)
+            .startOn(UIScheduler())
+            .map { $0.map(mapper) }
+            .observeOn(UIScheduler())
     }
     
     func rac_fetch<T: Entity>(request: Request<T>) -> SignalProducer<[T], Error> {

--- a/SugarRecord/Source/Reactive/ReactiveCocoa/ReactiveStorage+ReactiveCocoa.swift
+++ b/SugarRecord/Source/Reactive/ReactiveCocoa/ReactiveStorage+ReactiveCocoa.swift
@@ -1,6 +1,6 @@
 import Foundation
-import ReactiveCocoa
 import Result
+import ReactiveCocoa
 
 public extension Storage {
     

--- a/SugarRecordTests/Source/Realm/Storages/RealmDefaultStorageTests.swift
+++ b/SugarRecordTests/Source/Realm/Storages/RealmDefaultStorageTests.swift
@@ -79,6 +79,52 @@ class RealmDefaultStorageTests: QuickSpec {
             
         }
         
+        describe("-backgroundOperation:") {
+            
+            it("should notify about the completion when the operation completes") {
+                waitUntil(action: { (done) in
+                    subject.backgroundOperation({ (context, save) -> Void in
+                        // Do nothing
+                    }) { error in
+                        done()
+                    }
+                })
+            }
+            
+            it("should notify about the completion with the error if any is thrown") {
+                waitUntil(action: { (done) in
+                    let error: NSError = NSError(domain: "", code: -1, userInfo: nil)
+                    subject.backgroundOperation({ (context, save) throws -> Void in
+                        throw error
+                    }) { _error in
+                        expect(_error! as NSError) == error
+                        done()
+                    }
+                })
+            }
+            
+            it("should notify the completion block in the main thread") {
+                waitUntil(action: { (done) in
+                    subject.backgroundOperation({ (context, save) -> Void in
+                        // Do nothing
+                    }) { error in
+                        expect(NSThread.isMainThread()) == true
+                        done()
+                    }
+                })
+            }
+            
+            it("should execute the operation in a background thread") {
+                waitUntil(action: { (done) in
+                    subject.backgroundOperation({ (context, save) -> Void in
+                        expect(NSThread.isMainThread()) == false
+                        done()
+                    })
+                })
+            }
+            
+        }
+        
         describe("-observable") {
             
             var observable: RealmObservable<Issue>!


### PR DESCRIPTION
### What?
So far the `backgroundOperation` option was only available from the reactive interface. Now it's also non available from the non-reactive interface. 