### PR TITLE
Disabled carthage in travis line

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,11 +2,11 @@ COMMIT_MESSAGE = "Bump podspec to"
 
 lane :dependencies do
   cocoapods(podfile: "Example/")
-  carthage(command: "update")
+#  carthage(command: "update")
 end
 
 lane :tests do
-  scan(workspace: "Example/SugarRecord.xcworkspace", scheme: "SugarRecord_Tests", device: "iPhone 6", skip_build: true)
+  scan(workspace: "Example/SugarRecord.xcworkspace", scheme: "SugarRecord-Example", device: "iPhone 6", skip_build: true)
 end
 
 lane :carthage_project do
@@ -15,7 +15,7 @@ end
 
 lane :travis do
   dependencies
-  carthage_project
+#  carthage_project
   tests
   danger
 end


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/SugarRecord/issues/276)
### Short description

Fix broken travis-CI
### Solution

I entirely disabled Carthage in travis line, because `carthage update` was executing when travis-CI became frozen. There is note in Carthage repository that [installation](https://github.com/Carthage/Carthage#installing-carthage) with Homebrew works only on Xcode 7, maybe this is a reason why it doesn't work on travis.
### Implementation

Commented Carthage steps in travis line in Fastfile
### GIF

![Tests](http://i.giphy.com/gw3IWyGkC0rsazTi.gif)
