### PR TITLE
fixed documents directory for tvOS

### DIFF
--- a/SugarRecord/Source/Foundation/Utils/DirUtils.swift
+++ b/SugarRecord/Source/Foundation/Utils/DirUtils.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 func documentsDirectory() -> String {
-    let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+    #if os(tvOS)
+        let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
+    #else
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+    #endif
     return paths[0]
 }


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/SugarRecord/issues/308)

### Short description
This fixes a crash when attempting to create a core data store on a tvOS device.

### Solution
Just put a check for tvOS and picked the caches directory rather than documents when compiling for tvOS.

### Implementation
- Added an `if os` statement to catch for compiling for tvOS
- Changed folder from documents to caches only for tvOS (everybody else is cool)

### GIF
![Pretty rad](http://gph.is/1TV0t0w)