### PR TITLE
Use the right NSFetchedResultsControllerDelegate method. Fix for Dele…

### DIFF
--- a/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
+++ b/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
@@ -50,8 +50,8 @@ public class CoreDataObservable<T: NSManagedObject>: RequestObservable<T>, NSFet
 
 
     // MARK: - NSFetchedResultsControllerDelegate
-
-    @nonobjc public func controller(controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeObject anObject: AnyObject, atIndexPath indexPath: IndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+    
+    public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
         switch type {
         case .delete:
             self.batchChanges.append(.delete(indexPath![0], anObject as! T))


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/XXXX/issues/YYY)

### Short description
> Fix the Issue where one of the NSFetchedResultsControllerDelegate method was not being called. 

### Solution
> The method signature of the delgate has been changed. Hence I just replaced the method with the right one. `func controller(NSFetchedResultsController<NSFetchRequestResult>, didChange: NSFetchedResultsSectionInfo, atSectionIndex: Int, for: NSFetchedResultsChangeType)` 

### Implementation
> Detail in a checklist the steps that you took to implement the PR.

- [x] Remove `@nonobjc public func controller(controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeObject anObject: AnyObject, atIndexPath indexPath: IndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)'
- [x] Replace with `public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)` 

### GIF
> Find a descriptive GIF for your PR. Because we :heart: fun at Carambalabs.
…gate method not being called. (CoreDataObservable with no informations #307)