### PR TITLE
Updated Realm-Cocoa reference to latest version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v1.1.0"
+github "realm/realm-cocoa" "v2.4.3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v2.4.3"
+github "realm/realm-cocoa" "v2.5.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v1.1.0"
+github "realm/realm-cocoa" "v2.4.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v2.4.3"
+github "realm/realm-cocoa" "v2.5.1"

--- a/SugarRecord/Source/Realm/Entities/RealmObservable.swift
+++ b/SugarRecord/Source/Realm/Entities/RealmObservable.swift
@@ -26,7 +26,7 @@ open class RealmObservable<T: Object>: RequestObservable<T> {
             realmObjects = realmObjects.filter(predicate)
         }
         if let sortDescriptor = self.request.sortDescriptor {
-            realmObjects = realmObjects.sorted(byProperty: sortDescriptor.key!, ascending: sortDescriptor.ascending)
+            realmObjects = realmObjects.sorted(byKeyPath: sortDescriptor.key!, ascending: sortDescriptor.ascending)
         }
         self.notificationToken = realmObjects.addNotificationBlock { (changes: RealmCollectionChange<Results<T>>) in
             closure(self.map(changes))

--- a/SugarRecord/Source/Realm/Extensions/Realm.swift
+++ b/SugarRecord/Source/Realm/Extensions/Realm.swift
@@ -10,7 +10,7 @@ extension Realm: Context {
             results = results.filter(predicate)
         }
         if let sortDescriptor = request.sortDescriptor, let key = sortDescriptor.key {
-            results = results.sorted(byProperty: key, ascending: sortDescriptor.ascending)
+            results = results.sorted(byKeyPath: key, ascending: sortDescriptor.ascending)
         }
         return results.toArray().map { $0 as Any as! T }
     }


### PR DESCRIPTION
### Short description
> Like the title says, this updates the reference to Realm. At the moment, SugarRecord still relies on version 1.1.0 of Realm, but this was release a while ago.

### Solution
> Simply updated the version number of Carthage and then updated 2 API calls.