### PR TITLE
[cleanup-realm] Remove references to Realm from the Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa" "v1.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa" "v1.1.0"


### PR DESCRIPTION
### Short description
The Realm support was dropped in the last version. However, the `Cartfile` wasn't updated accordingly.

### Solution
I've updated the `Cartfile` remove the references to Realm.

### GIF

>![gif](https://media.giphy.com/media/Ujvt8itIEyBpK/giphy.gif)