### PR TITLE
Change access modifier of NSManagedObject.entityName class var extens…

### DIFF
--- a/SugarRecord/Source/CoreData/Extensions/NSManagedObject.swift
+++ b/SugarRecord/Source/CoreData/Extensions/NSManagedObject.swift
@@ -5,7 +5,7 @@ import CoreData
 
 extension NSManagedObject {
     
-    public class var entityName: String {
+    open class var entityName: String {
         return NSStringFromClass(self).components(separatedBy: ".").last!
     }
     


### PR DESCRIPTION
…ion to allow overriding in clients of the library

**Related issue:** [Link](https://github.com/carambalabs/SugarRecord/issues/321)

### Short description

Change `NSManagedObject.entityName` class var from `public` to `open` to allow clients of the library to alter the property entity name, if necessary.

Sometimes, providing a class name that differs from the entity's name in .xcdatamodeld is needed to avoid clashes with existing symbols in code. Allowing overriding of this property permits adapting such changes to SugarRecord, as well.

### Solution
> Describe the solution you came up with and the reasons that led you to that solution. If you thought about other solutions don't forget about mentioning them.

### Implementation

- [x] Simply alter `public class var entityName: String` to `open class var entityName:String` in NSManagedObject.swift

### GIF

![](https://cloud.githubusercontent.com/assets/6502879/25871758/f35d8d7a-34de-11e7-882c-87ec780e8185.gif)
Relevant: me furiously coding the seemingly endless diff for this change. No PoweGloves survived in the making of this PR.
