### PR TITLE
Adding Count operation to Context

### DIFF
--- a/SugarRecord/Source/CoreData/Extensions/NSManagedObjectContext.swift
+++ b/SugarRecord/Source/CoreData/Extensions/NSManagedObjectContext.swift
@@ -18,6 +18,16 @@ extension NSManagedObjectContext: Context {
         return typedResults
     }
     
+    public func count<T: Entity>(_ request: FetchRequest<T>) throws -> Int {
+        guard let entity = T.self as? NSManagedObject.Type else { throw StorageError.invalidType }
+        let fetchRequest: NSFetchRequest =  NSFetchRequest<NSFetchRequestResult>(entityName: entity.entityName)
+        fetchRequest.predicate = request.predicate
+        fetchRequest.fetchOffset = request.fetchOffset
+        fetchRequest.fetchLimit = request.fetchLimit
+        let result = try self.count(for: fetchRequest)
+        return result
+    }
+    
     public func insert<T: Entity>(_ entity: T) throws {}
     
     public func new<T: Entity>() throws -> T {

--- a/SugarRecord/Source/Foundation/Protocols/Context.swift
+++ b/SugarRecord/Source/Foundation/Protocols/Context.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol Context: Requestable {
     
     func fetch<T: Entity>(_ request: FetchRequest<T>) throws -> [T]
+    func count<T: Entity>(_ request: FetchRequest<T>) throws -> Int
     func insert<T: Entity>(_ entity: T) throws
     func new<T: Entity>() throws -> T
     func create<T: Entity>() throws -> T


### PR DESCRIPTION
### Short description

Adds a method `Context.count<T>` and implement it in the `NSManagedObjectContext` extension.

### Solution

Counting number of results without getting the objects is a useful functionality, specially when the objects are heavy-weight to fetch simply to be counted and then discarded.

### Implementation

- [√] Add new protocol method `Context.count<T: Entity>(_:) throws -> Int`;
- [√] Implement this protocol on existing extension of `NSManagedObjectContext` with other protocol requirements.

### GIF

CoreData with brand new `count` method:

![200](https://cloud.githubusercontent.com/assets/6502879/26764220/5f7c8b1e-4939-11e7-9e34-884009e07b50.gif)

_...that gives 02 (two) `UserEntity` instances._