### PR TITLE
Correctly reference indexPath row when calculating changes.

### DIFF
--- a/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
+++ b/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
@@ -54,11 +54,11 @@ public class CoreDataObservable<T: NSManagedObject>: RequestObservable<T>, NSFet
     public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
         switch type {
         case .delete:
-            self.batchChanges.append(.delete(indexPath![0], anObject as! T))
+            self.batchChanges.append(.delete(indexPath!.row, anObject as! T))
         case .insert:
-            self.batchChanges.append(.insert(newIndexPath![0], anObject as! T))
+            self.batchChanges.append(.insert(newIndexPath!.row, anObject as! T))
         case .update:
-            self.batchChanges.append(.update(indexPath![0], anObject as! T))
+            self.batchChanges.append(.update(indexPath!.row, anObject as! T))
         default: break
         }
     }


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/SugarRecord/issues/335)

### Short description
Fixes CoreDataObservable reporting incorrect indices in observe() callback.

### Solution
I noticed that we were directly attempting to subscript indexPath[0], and I wasn't 100% sure what that meant semantically. I tried different subscripts out of curiosity, and found that indexPath[1] was returning the indices I expected in my client code. I then looked at historical versions of the file and noticed at one point (pre swift 3), this function was using indexPath.row instead of a subscript. Semantically this seemed correct, and after testing it seems to be functioning as expected.

### Implementation
- [x] Debugged current code against my client application
- [x] Tried various subscript values for IndexPath
- [x] Looked at historical commits on this file, found previous versions used indexPath.row
- [x] Tested indexPath.row against my client application
- [x] Made change on fork
- [x] Pulled fork version as dependency + test
![](http://i.imgur.com/lSjkmNj.gif)