### PR TITLE
Added MacOS Example, Tests, made RequestObservable compatible with MacOS 10.12+

### DIFF
--- a/Example/MacOSTests/Info.plist
+++ b/Example/MacOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -16,3 +16,20 @@ target 'SugarRecord_Tests' do
   pod "OHHTTPStubs"
   pod 'OHHTTPStubs/Swift'
 end
+
+target 'SugarRecord-MacOSExample' do
+  pod 'SnapKit'
+  pod 'SugarRecord', :path => "../"
+  pod 'SugarRecord/CoreData', :path => "../"
+  pod 'SugarRecord/CoreData+iCloud', :path => "../"
+end
+
+target 'SugarRecord_MacOSTests' do
+  pod 'SugarRecord', :path => "../"
+  pod 'SugarRecord/CoreData', :path => "../"
+  pod 'SugarRecord/CoreData+iCloud', :path => "../"
+  pod 'Quick', "~> 0.10"
+  pod 'Nimble', '~> 5.0'
+  pod "OHHTTPStubs"
+  pod 'OHHTTPStubs/Swift'
+end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -18,12 +18,12 @@ PODS:
   - Quick (0.10.0)
   - Result (3.2.1)
   - SnapKit (3.2.0)
-  - SugarRecord (3.1.1):
-    - SugarRecord/CoreData (= 3.1.1)
-    - SugarRecord/CoreData+iCloud (= 3.1.1)
-  - SugarRecord/CoreData (3.1.1):
+  - SugarRecord (3.1.2):
+    - SugarRecord/CoreData (= 3.1.2)
+    - SugarRecord/CoreData+iCloud (= 3.1.2)
+  - SugarRecord/CoreData (3.1.2):
     - Result (~> 3.0)
-  - SugarRecord/CoreData+iCloud (3.1.1):
+  - SugarRecord/CoreData+iCloud (3.1.2):
     - Result (~> 3.0)
 
 DEPENDENCIES:
@@ -38,7 +38,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   SugarRecord:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
@@ -46,8 +46,8 @@ SPEC CHECKSUMS:
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
   Result: 2453a22e5c5b11c0c3a478736e82cd02f763b781
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
-  SugarRecord: d3c8f4df864518bf30e5bf32a62564b8397fe508
+  SugarRecord: be6aa5c18b4a4dec0de4c1f49fc61c85eabb5328
 
-PODFILE CHECKSUM: d61f456397a3e8bb696c939fc5e85337d5040894
+PODFILE CHECKSUM: 8f4854ebcb294b575e611ae8266ca5644ad58e63
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.1

--- a/Example/SugarRecord-ExampleMacOS/Resources/Assets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/SugarRecord-ExampleMacOS/Resources/Assets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example/SugarRecord-ExampleMacOS/Resources/DataModels/Basic.xcdatamodeld/Basic.xcdatamodel/contents
+++ b/Example/SugarRecord-ExampleMacOS/Resources/DataModels/Basic.xcdatamodeld/Basic.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Xcode 7.0">
+    <entity name="BasicObject" representedClassName=".BasicObject" syncable="YES">
+        <attribute name="date" attributeType="Date" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="BasicObject" positionX="-63" positionY="-18" width="128" height="75"/>
+    </elements>
+</model>

--- a/Example/SugarRecord-ExampleMacOS/Resources/Storyboards/Base.lproj/Main.storyboard
+++ b/Example/SugarRecord-ExampleMacOS/Resources/Storyboards/Base.lproj/Main.storyboard
@@ -1,0 +1,926 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13122.19" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.19"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="SugarRecord-ExampleMacOS" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="SugarRecord-ExampleMacOS" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About SugarRecord-ExampleMacOS" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide SugarRecord-ExampleMacOS" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit SugarRecord-ExampleMacOS" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                                        <connections>
+                                                            <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="SugarRecord-ExampleMacOS Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="SugarRecord_MacOSExample" customModuleProvider="target"/>
+                <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="B49-Nl-mHu" kind="relationship" relationship="window.shadowedContentViewController" id="anG-FS-jgY"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--Split View Controller-->
+        <scene sceneID="Pvc-4j-4SG">
+            <objects>
+                <splitViewController id="B49-Nl-mHu" customClass="SplitViewController" customModule="SugarRecord_MacOSExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <splitViewItems>
+                        <splitViewItem id="bwg-ro-zTv"/>
+                        <splitViewItem id="mVU-TK-4yV"/>
+                    </splitViewItems>
+                    <splitView key="splitView" dividerStyle="thin" vertical="YES" id="hPC-6R-rpq">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <connections>
+                            <outlet property="delegate" destination="B49-Nl-mHu" id="v85-J7-Ix0"/>
+                        </connections>
+                    </splitView>
+                    <connections>
+                        <segue destination="uaT-Ku-M84" kind="relationship" relationship="splitItems" id="TW0-GS-to2"/>
+                        <segue destination="Xnn-Hs-q4c" kind="relationship" relationship="splitItems" id="VNL-ZF-wXR"/>
+                    </connections>
+                </splitViewController>
+                <customObject id="558-LJ-Mwq" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="768"/>
+        </scene>
+        <!--List View Controller-->
+        <scene sceneID="tuG-9a-Ja3">
+            <objects>
+                <viewController id="uaT-Ku-M84" customClass="ListViewController" customModule="SugarRecord_MacOSExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="rWf-pi-SuF">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5O0-Ve-9CH">
+                                <rect key="frame" x="0.0" y="24" width="450" height="276"/>
+                                <clipView key="contentView" id="VWT-8H-C0e">
+                                    <rect key="frame" x="1" y="0.0" width="448" height="275"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" headerView="fY8-19-rQ8" viewBased="YES" id="bgY-Xo-gfL">
+                                            <rect key="frame" x="0.0" y="0.0" width="450" height="252"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn width="447" minWidth="40" maxWidth="1000" id="ekn-sO-cdB">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Name">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="BLy-kN-Dwn">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView identifier="simple_cell" id="jUn-cY-8ZB">
+                                                            <rect key="frame" x="1" y="1" width="447" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E8w-Id-i8i">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="447" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="o0s-L7-6vc">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <connections>
+                                                                <outlet property="textField" destination="E8w-Id-i8i" id="mrj-qQ-y34"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                        </tableView>
+                                    </subviews>
+                                </clipView>
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="5TM-yK-8rU">
+                                    <rect key="frame" x="1" y="259" width="448" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="fZD-vd-Oj5">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <tableHeaderView key="headerView" id="fY8-19-rQ8">
+                                    <rect key="frame" x="0.0" y="0.0" width="450" height="23"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableHeaderView>
+                            </scrollView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="28d-tj-rmz">
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="24"/>
+                                <subviews>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6ZO-eD-dOi">
+                                        <rect key="frame" x="427" y="1" width="21" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="6ZO-eD-dOi" secondAttribute="height" multiplier="21:19" id="1bp-XG-i0g"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" enabled="NO" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Y1f-FC-age">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="deleteEntityWithSender:" target="uaT-Ku-M84" id="gs0-t0-HmC"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9nP-EN-ars">
+                                        <rect key="frame" x="402" y="1" width="21" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="9nP-EN-ars" secondAttribute="height" multiplier="21:19" id="vio-b7-Fir"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="eWR-u9-LF9">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="addEntityWithSender:" target="uaT-Ku-M84" id="OXt-Nh-qi5"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="9nP-EN-ars" firstAttribute="centerY" secondItem="28d-tj-rmz" secondAttribute="centerY" id="38i-Xh-qgp"/>
+                                    <constraint firstItem="9nP-EN-ars" firstAttribute="width" secondItem="9nP-EN-ars" secondAttribute="height" multiplier="21:19" id="D7Z-Pv-5tl"/>
+                                    <constraint firstAttribute="trailing" secondItem="6ZO-eD-dOi" secondAttribute="trailing" constant="2" id="M5n-Bp-Uaj"/>
+                                    <constraint firstItem="6ZO-eD-dOi" firstAttribute="leading" secondItem="9nP-EN-ars" secondAttribute="trailing" constant="4" id="Mus-w9-0mh"/>
+                                    <constraint firstItem="6ZO-eD-dOi" firstAttribute="centerY" secondItem="28d-tj-rmz" secondAttribute="centerY" id="kUA-Yj-NPf"/>
+                                    <constraint firstAttribute="height" constant="24" id="lZK-aJ-rVg"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="28d-tj-rmz" firstAttribute="top" secondItem="5O0-Ve-9CH" secondAttribute="bottom" id="7y3-K1-8iH"/>
+                            <constraint firstAttribute="bottom" secondItem="28d-tj-rmz" secondAttribute="bottom" id="Ka8-bh-GFf"/>
+                            <constraint firstItem="28d-tj-rmz" firstAttribute="leading" secondItem="rWf-pi-SuF" secondAttribute="leading" id="QCk-G0-6LH"/>
+                            <constraint firstItem="5O0-Ve-9CH" firstAttribute="top" secondItem="rWf-pi-SuF" secondAttribute="top" id="SxF-br-Q5J"/>
+                            <constraint firstAttribute="trailing" secondItem="5O0-Ve-9CH" secondAttribute="trailing" id="Vr1-eJ-MEF"/>
+                            <constraint firstItem="5O0-Ve-9CH" firstAttribute="leading" secondItem="rWf-pi-SuF" secondAttribute="leading" id="kPy-Bp-Z7E"/>
+                            <constraint firstAttribute="trailing" secondItem="28d-tj-rmz" secondAttribute="trailing" id="qtW-Bv-pgI"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="deleteButton" destination="6ZO-eD-dOi" id="TQw-uI-lzo"/>
+                        <outlet property="tableView" destination="bgY-Xo-gfL" id="eOm-rt-g4V"/>
+                    </connections>
+                </viewController>
+                <customObject id="vYr-AL-5Ly" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="673" y="572"/>
+        </scene>
+        <!--Details View Controller-->
+        <scene sceneID="BBr-2E-1db">
+            <objects>
+                <viewController id="Xnn-Hs-q4c" customClass="DetailsViewController" customModule="SugarRecord_MacOSExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="TID-oj-G1k">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GDv-rJ-dqd">
+                                <rect key="frame" x="18" y="263" width="40" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name" id="peW-9e-GHd">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eRa-0e-dgm">
+                                <rect key="frame" x="20" y="233" width="96" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="TBt-Ag-P1l">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <action selector="nameChangedWithSender:" target="Xnn-Hs-q4c" id="imh-J5-prD"/>
+                                </connections>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kcC-5n-Yfv">
+                                <rect key="frame" x="20" y="193" width="33" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Date" id="c4N-OB-cbY">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <datePicker verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dgl-JX-K4r">
+                                <rect key="frame" x="20" y="162" width="97" height="27"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <datePickerCell key="cell" enabled="NO" borderStyle="bezel" alignment="left" id="9Li-Wi-XvQ">
+                                    <font key="font" metaFont="system"/>
+                                    <date key="date" timeIntervalSinceReferenceDate="-595929600">
+                                        <!--1982-02-12 16:00:00 +0000-->
+                                    </date>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                </datePickerCell>
+                                <connections>
+                                    <action selector="dateChangedWithSender:" target="Xnn-Hs-q4c" id="LHy-0g-sc6"/>
+                                </connections>
+                            </datePicker>
+                        </subviews>
+                    </view>
+                    <connections>
+                        <outlet property="datePicker" destination="dgl-JX-K4r" id="hTd-UX-QSE"/>
+                        <outlet property="nameTextField" destination="eRa-0e-dgm" id="dWK-Ey-FiK"/>
+                    </connections>
+                </viewController>
+                <customObject id="46x-lv-ZHQ" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="673" y="979"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
+    </resources>
+</document>

--- a/Example/SugarRecord-ExampleMacOS/Source/Examples/CoreData/Models/BasicObject.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Examples/CoreData/Models/BasicObject.swift
@@ -1,0 +1,15 @@
+import Foundation
+import CoreData
+
+class BasicObject: NSManagedObject {
+    
+    // Insert code here to add functionality to your managed object subclass
+    
+}
+
+extension BasicObject {
+    
+    @NSManaged var date: Date?
+    @NSManaged var name: String?
+    
+}

--- a/Example/SugarRecord-ExampleMacOS/Source/Examples/CoreData/Models/CoreDataBasicEntity.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Examples/CoreData/Models/CoreDataBasicEntity.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+class CoreDataBasicEntity {
+    
+    // MARK: - Attributes
+    
+    let dateString: String
+    let name: String
+    
+    // MARK: - Init 
+    
+    init(object: BasicObject) {
+        let dateFormater = DateFormatter()
+        dateFormater.timeStyle = DateFormatter.Style.short
+        dateFormater.dateStyle = DateFormatter.Style.short
+        self.dateString = dateFormater.string(from: object.date! as Date)
+        self.name = object.name!
+    }
+}

--- a/Example/SugarRecord-ExampleMacOS/Source/Examples/DetailsViewController.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Examples/DetailsViewController.swift
@@ -1,0 +1,53 @@
+//
+//  DetailsViewController.swift
+//  SugarRecord_Example
+//
+//  Created by Jorge Martín Espinosa on 10/7/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Cocoa
+
+class DetailsViewController: NSViewController {
+    
+    @IBOutlet weak var nameTextField: NSTextField!
+    @IBOutlet weak var datePicker: NSDatePicker!
+    
+    var selectedItem: BasicObject? {
+        didSet {
+            if self.selectedItem != nil {
+                nameTextField.stringValue = self.selectedItem!.name!
+                nameTextField.isEnabled = true
+                
+                datePicker.dateValue = self.selectedItem!.date!
+                datePicker.isEnabled = true
+            } else {
+                nameTextField.stringValue = ""
+                nameTextField.isEnabled = false
+                
+                datePicker.isEnabled = false
+            }
+        }
+    }
+    
+    @IBAction func nameChanged(sender: Any?) {
+        try! db.operation({ (context, save) in
+            if let item = try! context.request(BasicObject.self)
+                .filtered(with: "name", equalTo: self.selectedItem!.name ?? "").fetch().first {
+                item.name = self.nameTextField!.stringValue
+                save()
+            }
+        })
+    }
+    
+    @IBAction func dateChanged(sender: Any?) {
+        try! db.operation({ (context, save) in
+            if let item = try! context.request(BasicObject.self)
+                .filtered(with: "name", equalTo: self.selectedItem!.name ?? "").fetch().first {
+                item.date = self.datePicker!.dateValue
+                save()
+            }
+        })
+    }
+}

--- a/Example/SugarRecord-ExampleMacOS/Source/Examples/Helpers/Directory.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Examples/Helpers/Directory.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+func databasePath(_ name: String) -> String {
+    let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory,.userDomainMask, true)[0] as String
+    return documentsPath + "/\(name)"
+}

--- a/Example/SugarRecord-ExampleMacOS/Source/Examples/Helpers/Random.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Examples/Helpers/Random.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+
+func randomStringWithLength (_ len : Int) -> NSString {
+    let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    let randomString : NSMutableString = NSMutableString(capacity: len)
+    for _ in 0 ..< len {
+        let length = UInt32 (letters.length)
+        let rand = arc4random_uniform(length)
+        randomString.appendFormat("%C", letters.character(at: Int(rand)))
+    }
+    return randomString
+}

--- a/Example/SugarRecord-ExampleMacOS/Source/Main/AppDelegate.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Main/AppDelegate.swift
@@ -1,0 +1,33 @@
+//
+//  AppDelegate.swift
+//  SugarRecord-ExampleMacOS
+//
+//  Created by Jorge Martín Espinosa on 10/7/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Cocoa
+import SugarRecord
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+
+
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Insert code here to initialize your application
+    }
+
+    func applicationWillTerminate(_ aNotification: Notification) {
+        
+    }
+
+}
+
+var db: CoreDataDefaultStorage = {
+    let store = CoreDataStore.named("cd_basic")
+    let bundle = Bundle.main
+    let model = CoreDataObjectModel.merged([bundle])
+    let defaultStorage = try! CoreDataDefaultStorage(store: store, model: model)
+    return defaultStorage
+}()

--- a/Example/SugarRecord-ExampleMacOS/Source/Main/ListViewController.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Main/ListViewController.swift
@@ -1,0 +1,115 @@
+//
+//  ViewController.swift
+//  SugarRecord-ExampleMacOS
+//
+//  Created by Jorge Martín Espinosa on 10/7/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Cocoa
+import SugarRecord
+import CoreData
+
+class ListViewController: NSViewController, NSTableViewDelegate, NSTableViewDataSource {
+    
+    // MARK: - Attributes
+    
+    lazy var entitiesObservable: RequestObservable<BasicObject> = {
+        let request = FetchRequest<BasicObject>().sorted(with: "date", ascending: false)
+        return db.observable(request: request)
+    }()
+    
+    var entities: [BasicObject] = [] {
+        didSet {
+            updateData()
+        }
+    }
+    
+    @IBOutlet weak var tableView: NSTableView!
+    @IBOutlet weak var deleteButton: NSButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.dataSource = self
+        tableView.delegate = self
+        
+        entitiesObservable.observe { changes in
+            switch(changes) {
+                case .initial(let objects):
+                    self.entities = objects
+                case .update(let deletions, let insertions, let modifications):
+                    deletions.forEach {
+                        self.entities.remove(at: $0)
+                    }
+                    
+                    insertions.forEach { (position, item) in
+                        self.entities.insert(item, at: position)
+                    }
+                    
+                    print("\(deletions.count) deleted | \(insertions.count) inserted | \(modifications.count) modified")
+                case .error(let error):
+                    print("Something went wrong: \(error)")
+            }
+            self.updateData()
+        }
+    }
+    
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        if let cell = tableView.make(withIdentifier: "simple_cell", owner: nil) as? NSTableCellView {
+            cell.textField?.stringValue = entities[row].name ?? ""
+            return cell
+        }
+        return nil
+    }
+    
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        if tableView.selectedRow >= 0 && tableView.selectedRow < entities.count {
+            let selectedItemValues = entities[tableView.selectedRow]
+            let fetchRequest = FetchRequest<BasicObject>().filtered(with: "name", equalTo: selectedItemValues.name ?? "")
+            if let item = try? db.fetch(fetchRequest) {
+                (parent as? SplitViewController)?.onSelectionChanged(item: item.first)
+            }
+            deleteButton.isEnabled = true
+        } else {
+            (parent as? SplitViewController)?.onSelectionChanged(item: nil)
+            deleteButton.isEnabled = false
+        }
+    }
+    
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return entities.count
+    }
+    
+    @IBAction func addEntity(sender: Any?) {
+        try! db.operation { (context, save) -> Void in
+            let _object: BasicObject = try! context.new()
+            _object.date = Date()
+            _object.name = randomStringWithLength(10) as String
+            try! context.insert(_object)
+            save()
+        }
+    }
+    
+    @IBAction func deleteEntity(sender: Any?) {
+        let _object = self.entities[tableView.selectedRow]
+        try! db.operation { (context, save) -> Void in
+            if let object = try! context.request(BasicObject.self).filtered(with: "name", equalTo: _object.name ?? "").fetch().first {
+                try! context.remove(object)
+                save()
+            }
+        }
+    }
+    
+    func updateData() {
+        self.tableView.reloadData()
+    }
+
+    override var representedObject: Any? {
+        didSet {
+        // Update the view, if already loaded.
+        }
+    }
+    
+}
+

--- a/Example/SugarRecord-ExampleMacOS/Source/Main/SplitViewController.swift
+++ b/Example/SugarRecord-ExampleMacOS/Source/Main/SplitViewController.swift
@@ -1,0 +1,22 @@
+//
+//  SplitViewController.swift
+//  SugarRecord_Example
+//
+//  Created by Jorge Martín Espinosa on 10/7/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Cocoa
+
+class SplitViewController: NSSplitViewController {
+    
+    var detailsViewController: DetailsViewController? {
+        return splitViewItems[1].viewController as? DetailsViewController
+    }
+    
+    func onSelectionChanged(item: BasicObject?) {
+        detailsViewController?.selectedItem = item
+    }
+    
+}

--- a/Example/SugarRecord-ExampleMacOS/Supporting Files/Info.plist
+++ b/Example/SugarRecord-ExampleMacOS/Supporting Files/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 CocoaPods. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Example/SugarRecord-ExampleMacOS/Supporting Files/SugarRecord_ExampleMacOS.entitlements
+++ b/Example/SugarRecord-ExampleMacOS/Supporting Files/SugarRecord_ExampleMacOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/Example/SugarRecord.xcodeproj/project.pbxproj
+++ b/Example/SugarRecord.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D4B9E0213B3D0246753DDE6 /* Pods_SugarRecord_MacOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51050438EF72D11B40A20FA7 /* Pods_SugarRecord_MacOSTests.framework */; };
 		23E13E5B1D96896300204C82 /* CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E341D96896300204C82 /* CoreData.swift */; };
 		23E13E5D1D96896300204C82 /* Track+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E381D96896300204C82 /* Track+CoreDataProperties.swift */; };
 		23E13E5E1D96896300204C82 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E391D96896300204C82 /* Track.swift */; };
@@ -31,11 +32,48 @@
 		23FB2C051E97C8BB00432BCB /* CoreDataBasicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FB2BFA1E97C8BB00432BCB /* CoreDataBasicView.swift */; };
 		23FB2C061E97C8BB00432BCB /* BasicObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FB2BFC1E97C8BB00432BCB /* BasicObject.swift */; };
 		23FB2C071E97C8BB00432BCB /* CoreDataBasicEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FB2BFD1E97C8BB00432BCB /* CoreDataBasicEntity.swift */; };
+		4DE9B2AC1F138FF900B59AEE /* CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E341D96896300204C82 /* CoreData.swift */; };
+		4DE9B2AD1F138FF900B59AEE /* Track+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E381D96896300204C82 /* Track+CoreDataProperties.swift */; };
+		4DE9B2AE1F138FF900B59AEE /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E391D96896300204C82 /* Track.swift */; };
+		4DE9B2AF1F138FF900B59AEE /* DataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E3E1D96896300204C82 /* DataModel.xcdatamodeld */; };
+		4DE9B2B01F138FF900B59AEE /* CoreDataChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E431D96896300204C82 /* CoreDataChangeTests.swift */; };
+		4DE9B2B11F138FF900B59AEE /* CoreDataObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E441D96896300204C82 /* CoreDataObservableTests.swift */; };
+		4DE9B2B21F138FF900B59AEE /* ObjectModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E451D96896300204C82 /* ObjectModelTests.swift */; };
+		4DE9B2B31F138FF900B59AEE /* OptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E461D96896300204C82 /* OptionsTests.swift */; };
+		4DE9B2B41F138FF900B59AEE /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E471D96896300204C82 /* StoreTests.swift */; };
+		4DE9B2B51F138FF900B59AEE /* CoreDataDefaultStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E491D96896300204C82 /* CoreDataDefaultStorageTests.swift */; };
+		4DE9B2B61F138FF900B59AEE /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E4C1D96896300204C82 /* RequestTests.swift */; };
+		4DE9B2B71F138FF900B59AEE /* DirUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E4E1D96896300204C82 /* DirUtilsTests.swift */; };
+		4DE9B2B81F138FF900B59AEE /* VersionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E501D96896300204C82 /* VersionControllerTests.swift */; };
+		4DE9B2B91F138FF900B59AEE /* VersionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E511D96896300204C82 /* VersionProviderTests.swift */; };
+		4DE9B2C31F13913300B59AEE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2C21F13913300B59AEE /* AppDelegate.swift */; };
+		4DE9B2C51F13913300B59AEE /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2C41F13913300B59AEE /* ListViewController.swift */; };
+		4DE9B2C71F13913300B59AEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DE9B2C61F13913300B59AEE /* Assets.xcassets */; };
+		4DE9B2CA1F13913300B59AEE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DE9B2C81F13913300B59AEE /* Main.storyboard */; };
+		4DE9B2E01F139B9B00B59AEE /* BasicObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2DE1F139A2C00B59AEE /* BasicObject.swift */; };
+		4DE9B2E11F139B9B00B59AEE /* CoreDataBasicEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2DF1F139A2C00B59AEE /* CoreDataBasicEntity.swift */; };
+		4DE9B2E51F139C3700B59AEE /* Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E8B1D96899000204C82 /* Directory.swift */; };
+		4DE9B2E61F139C3700B59AEE /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E13E8C1D96899000204C82 /* Random.swift */; };
+		4DE9B2E71F139CA200B59AEE /* Basic.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2D51F1399CA00B59AEE /* Basic.xcdatamodeld */; };
+		4DE9B2E91F13A0F600B59AEE /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2E81F13A0F600B59AEE /* SplitViewController.swift */; };
+		4DE9B2EB1F13A18C00B59AEE /* DetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2EA1F13A18C00B59AEE /* DetailsViewController.swift */; };
+		4DE9B2EC1F13A35700B59AEE /* DetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2EA1F13A18C00B59AEE /* DetailsViewController.swift */; };
+		4DE9B2ED1F13A35700B59AEE /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE9B2E81F13A0F600B59AEE /* SplitViewController.swift */; };
 		7F0014DAE56FEBE9A77EB8F3 /* Pods_SugarRecord_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE4511BDA74E45A8EA0229D9 /* Pods_SugarRecord_Tests.framework */; };
+		9BF9E2C7A1F9D1D232693210 /* Pods_SugarRecord_MacOSExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51C31F64CDE7FD4553FC46C1 /* Pods_SugarRecord_MacOSExample.framework */; };
 		A682778445C166ABA1550ECF /* Pods_SugarRecord_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB6674BDC2C223325C9246F4 /* Pods_SugarRecord_Example.framework */; };
+		E9824064F609CB4C02C76B65 /* Pods_SugarRecord_ExampleMacOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88F9F4CFBFCB1137A2C0BBF0 /* Pods_SugarRecord_ExampleMacOS.framework */; };
+		EFB805D2889B4336C9072AB8 /* Pods_MacOSTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A6ED7D1E3A83450EF0B0BC5 /* Pods_MacOSTest.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4DE9B2D11F13916400B59AEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 607FACC81AFB9204008FA782 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DE9B2BF1F13913300B59AEE;
+			remoteInfo = "SugarRecord-ExampleMacOS";
+		};
 		607FACE61AFB9204008FA782 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 607FACC81AFB9204008FA782 /* Project object */;
@@ -71,21 +109,68 @@
 		23FB2BFA1E97C8BB00432BCB /* CoreDataBasicView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataBasicView.swift; sourceTree = "<group>"; };
 		23FB2BFC1E97C8BB00432BCB /* BasicObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicObject.swift; sourceTree = "<group>"; };
 		23FB2BFD1E97C8BB00432BCB /* CoreDataBasicEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataBasicEntity.swift; sourceTree = "<group>"; };
+		35FF60B77D16780A36BDC384 /* Pods-SugarRecord-MacOSExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord-MacOSExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord-MacOSExample/Pods-SugarRecord-MacOSExample.debug.xcconfig"; sourceTree = "<group>"; };
 		43D59494AB8B01F49D62B037 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		4B1CE16714333FEF4FCD084E /* Pods-SugarRecord-ExampleMacOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord-ExampleMacOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord-ExampleMacOS/Pods-SugarRecord-ExampleMacOS.release.xcconfig"; sourceTree = "<group>"; };
+		4B2199C871394D189D0CBFFF /* Pods-SugarRecord-ExampleMacOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord-ExampleMacOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord-ExampleMacOS/Pods-SugarRecord-ExampleMacOS.debug.xcconfig"; sourceTree = "<group>"; };
+		4DE9B2A21F138FC500B59AEE /* SugarRecord_MacOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SugarRecord_MacOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DE9B2AA1F138FDD00B59AEE /* Pods_SugarRecord_Tests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_SugarRecord_Tests.framework; path = "Pods/../build/Debug-iphoneos/Pods_SugarRecord_Tests.framework"; sourceTree = "<group>"; };
+		4DE9B2C01F13913300B59AEE /* SugarRecord-MacOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SugarRecord-MacOSExample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DE9B2C21F13913300B59AEE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4DE9B2C41F13913300B59AEE /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		4DE9B2C61F13913300B59AEE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4DE9B2C91F13913300B59AEE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		4DE9B2CB1F13913300B59AEE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4DE9B2CC1F13913300B59AEE /* SugarRecord_ExampleMacOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SugarRecord_ExampleMacOS.entitlements; sourceTree = "<group>"; };
+		4DE9B2D61F1399CA00B59AEE /* Basic.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Basic.xcdatamodel; sourceTree = "<group>"; };
+		4DE9B2DE1F139A2C00B59AEE /* BasicObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicObject.swift; sourceTree = "<group>"; };
+		4DE9B2DF1F139A2C00B59AEE /* CoreDataBasicEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataBasicEntity.swift; sourceTree = "<group>"; };
+		4DE9B2E31F139C2300B59AEE /* Directory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Directory.swift; sourceTree = "<group>"; };
+		4DE9B2E41F139C2300B59AEE /* Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
+		4DE9B2E81F13A0F600B59AEE /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
+		4DE9B2EA1F13A18C00B59AEE /* DetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsViewController.swift; sourceTree = "<group>"; };
+		4DE9B2F01F13BC4B00B59AEE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		51050438EF72D11B40A20FA7 /* Pods_SugarRecord_MacOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SugarRecord_MacOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		51C31F64CDE7FD4553FC46C1 /* Pods_SugarRecord_MacOSExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SugarRecord_MacOSExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54DE24CF394C35117CF642A6 /* Pods-SugarRecord_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord_Tests/Pods-SugarRecord_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		587F20500BE8B0716DFB56D2 /* Pods-MacOSTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacOSTest.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacOSTest/Pods-MacOSTest.release.xcconfig"; sourceTree = "<group>"; };
+		5A6ED7D1E3A83450EF0B0BC5 /* Pods_MacOSTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MacOSTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B476131E81A65EF61C0905C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* SugarRecord_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SugarRecord_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* SugarRecord_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SugarRecord_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65A181DD622A1F2F3D27044A /* SugarRecord.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SugarRecord.podspec; path = ../SugarRecord.podspec; sourceTree = "<group>"; };
+		7B2B361FEDD2996B9562BBB2 /* Pods-SugarRecord_MacOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord_MacOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord_MacOSTests/Pods-SugarRecord_MacOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		8026227C811CCCAE52CFE75A /* Pods-MacOSTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacOSTest.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MacOSTest/Pods-MacOSTest.debug.xcconfig"; sourceTree = "<group>"; };
+		88F9F4CFBFCB1137A2C0BBF0 /* Pods_SugarRecord_ExampleMacOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SugarRecord_ExampleMacOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		92C812F114142E61803D9DEF /* Pods-SugarRecord_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord_Example/Pods-SugarRecord_Example.release.xcconfig"; sourceTree = "<group>"; };
+		A48C60DE617E4E019B077F5A /* Pods-SugarRecord_MacOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord_MacOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord_MacOSTests/Pods-SugarRecord_MacOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		B12A993BAFFB1BD0E68DDEA2 /* Pods-SugarRecord-MacOSExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord-MacOSExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord-MacOSExample/Pods-SugarRecord-MacOSExample.release.xcconfig"; sourceTree = "<group>"; };
 		BB6674BDC2C223325C9246F4 /* Pods_SugarRecord_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SugarRecord_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE4511BDA74E45A8EA0229D9 /* Pods_SugarRecord_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SugarRecord_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF1427C1C51BC3D125AAFF0F /* Pods-SugarRecord_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SugarRecord_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SugarRecord_Tests/Pods-SugarRecord_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4DE9B29F1F138FC500B59AEE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EFB805D2889B4336C9072AB8 /* Pods_MacOSTest.framework in Frameworks */,
+				0D4B9E0213B3D0246753DDE6 /* Pods_SugarRecord_MacOSTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DE9B2BD1F13913300B59AEE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E9824064F609CB4C02C76B65 /* Pods_SugarRecord_ExampleMacOS.framework in Frameworks */,
+				9BF9E2C7A1F9D1D232693210 /* Pods_SugarRecord_MacOSExample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		607FACCD1AFB9204008FA782 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -359,18 +444,120 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
-		23FB2C031E97C8BB00432BCB /* Basic */ = {
+		4DE9B2C11F13913300B59AEE /* SugarRecord-ExampleMacOS */ = {
 			isa = PBXGroup;
 			children = (
+				4DE9B2DA1F1399F900B59AEE /* Supporting Files */,
+				4DE9B2D81F1399D900B59AEE /* Source */,
+				4DE9B2D31F1399C200B59AEE /* Resources */,
 			);
-			path = Basic;
+			path = "SugarRecord-ExampleMacOS";
 			sourceTree = "<group>";
 		};
-		23FB2C041E97C8BB00432BCB /* Models */ = {
+		4DE9B2D31F1399C200B59AEE /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				4DE9B2D91F1399E800B59AEE /* Storyboards */,
+				4DE9B2D71F1399D100B59AEE /* Assets */,
+				4DE9B2D41F1399CA00B59AEE /* DataModels */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		4DE9B2D41F1399CA00B59AEE /* DataModels */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2D51F1399CA00B59AEE /* Basic.xcdatamodeld */,
+			);
+			path = DataModels;
+			sourceTree = "<group>";
+		};
+		4DE9B2D71F1399D100B59AEE /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2C61F13913300B59AEE /* Assets.xcassets */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+		4DE9B2D81F1399D900B59AEE /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2EE1F13BC0E00B59AEE /* Main */,
+				4DE9B2DB1F139A1B00B59AEE /* Examples */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		4DE9B2D91F1399E800B59AEE /* Storyboards */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2C81F13913300B59AEE /* Main.storyboard */,
+			);
+			path = Storyboards;
+			sourceTree = "<group>";
+		};
+		4DE9B2DA1F1399F900B59AEE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2CB1F13913300B59AEE /* Info.plist */,
+				4DE9B2CC1F13913300B59AEE /* SugarRecord_ExampleMacOS.entitlements */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		4DE9B2DB1F139A1B00B59AEE /* Examples */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2E21F139C2300B59AEE /* Helpers */,
+				4DE9B2DC1F139A2000B59AEE /* CoreData */,
+				4DE9B2EA1F13A18C00B59AEE /* DetailsViewController.swift */,
+			);
+			path = Examples;
+			sourceTree = "<group>";
+		};
+		4DE9B2DC1F139A2000B59AEE /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2DD1F139A2C00B59AEE /* Models */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		4DE9B2DD1F139A2C00B59AEE /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2DE1F139A2C00B59AEE /* BasicObject.swift */,
+				4DE9B2DF1F139A2C00B59AEE /* CoreDataBasicEntity.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		4DE9B2E21F139C2300B59AEE /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2E31F139C2300B59AEE /* Directory.swift */,
+				4DE9B2E41F139C2300B59AEE /* Random.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		4DE9B2EE1F13BC0E00B59AEE /* Main */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2C21F13913300B59AEE /* AppDelegate.swift */,
+				4DE9B2C41F13913300B59AEE /* ListViewController.swift */,
+				4DE9B2E81F13A0F600B59AEE /* SplitViewController.swift */,
+			);
+			path = Main;
+			sourceTree = "<group>";
+		};
+		4DE9B2EF1F13BC4B00B59AEE /* MacOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				4DE9B2F01F13BC4B00B59AEE /* Info.plist */,
+			);
+			path = MacOSTests;
 			sourceTree = "<group>";
 		};
 		51C9EF80959BF8FABCA8F5A9 /* Pods */ = {
@@ -380,6 +567,14 @@
 				92C812F114142E61803D9DEF /* Pods-SugarRecord_Example.release.xcconfig */,
 				54DE24CF394C35117CF642A6 /* Pods-SugarRecord_Tests.debug.xcconfig */,
 				EF1427C1C51BC3D125AAFF0F /* Pods-SugarRecord_Tests.release.xcconfig */,
+				8026227C811CCCAE52CFE75A /* Pods-MacOSTest.debug.xcconfig */,
+				587F20500BE8B0716DFB56D2 /* Pods-MacOSTest.release.xcconfig */,
+				4B2199C871394D189D0CBFFF /* Pods-SugarRecord-ExampleMacOS.debug.xcconfig */,
+				4B1CE16714333FEF4FCD084E /* Pods-SugarRecord-ExampleMacOS.release.xcconfig */,
+				35FF60B77D16780A36BDC384 /* Pods-SugarRecord-MacOSExample.debug.xcconfig */,
+				B12A993BAFFB1BD0E68DDEA2 /* Pods-SugarRecord-MacOSExample.release.xcconfig */,
+				7B2B361FEDD2996B9562BBB2 /* Pods-SugarRecord_MacOSTests.debug.xcconfig */,
+				A48C60DE617E4E019B077F5A /* Pods-SugarRecord_MacOSTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -390,6 +585,8 @@
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for SugarRecord */,
 				607FACE81AFB9204008FA782 /* Tests */,
+				4DE9B2EF1F13BC4B00B59AEE /* MacOSTests */,
+				4DE9B2C11F13913300B59AEE /* SugarRecord-ExampleMacOS */,
 				607FACD11AFB9204008FA782 /* Products */,
 				51C9EF80959BF8FABCA8F5A9 /* Pods */,
 				CEEE802555381F009B6ADB04 /* Frameworks */,
@@ -401,6 +598,8 @@
 			children = (
 				607FACD01AFB9204008FA782 /* SugarRecord_Example.app */,
 				607FACE51AFB9204008FA782 /* SugarRecord_Tests.xctest */,
+				4DE9B2A21F138FC500B59AEE /* SugarRecord_MacOSTests.xctest */,
+				4DE9B2C01F13913300B59AEE /* SugarRecord-MacOSExample.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -457,8 +656,13 @@
 		CEEE802555381F009B6ADB04 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4DE9B2AA1F138FDD00B59AEE /* Pods_SugarRecord_Tests.framework */,
 				BB6674BDC2C223325C9246F4 /* Pods_SugarRecord_Example.framework */,
 				DE4511BDA74E45A8EA0229D9 /* Pods_SugarRecord_Tests.framework */,
+				5A6ED7D1E3A83450EF0B0BC5 /* Pods_MacOSTest.framework */,
+				88F9F4CFBFCB1137A2C0BBF0 /* Pods_SugarRecord_ExampleMacOS.framework */,
+				51C31F64CDE7FD4553FC46C1 /* Pods_SugarRecord_MacOSExample.framework */,
+				51050438EF72D11B40A20FA7 /* Pods_SugarRecord_MacOSTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -466,6 +670,47 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4DE9B2A11F138FC500B59AEE /* SugarRecord_MacOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DE9B2A91F138FC600B59AEE /* Build configuration list for PBXNativeTarget "SugarRecord_MacOSTests" */;
+			buildPhases = (
+				0582B3662692EE134120463A /* [CP] Check Pods Manifest.lock */,
+				4DE9B29E1F138FC500B59AEE /* Sources */,
+				4DE9B29F1F138FC500B59AEE /* Frameworks */,
+				4DE9B2A01F138FC500B59AEE /* Resources */,
+				04B17ADE8FF538577C6429AD /* [CP] Embed Pods Frameworks */,
+				E204E2D9D429AEED3BCF742C /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4DE9B2D21F13916400B59AEE /* PBXTargetDependency */,
+			);
+			name = SugarRecord_MacOSTests;
+			productName = MacOSTest;
+			productReference = 4DE9B2A21F138FC500B59AEE /* SugarRecord_MacOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		4DE9B2BF1F13913300B59AEE /* SugarRecord-MacOSExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DE9B2CD1F13913300B59AEE /* Build configuration list for PBXNativeTarget "SugarRecord-MacOSExample" */;
+			buildPhases = (
+				4B48A6FF26BA0B58AF134FD3 /* [CP] Check Pods Manifest.lock */,
+				4DE9B2BC1F13913300B59AEE /* Sources */,
+				4DE9B2BD1F13913300B59AEE /* Frameworks */,
+				4DE9B2BE1F13913300B59AEE /* Resources */,
+				04C55B11D074FA429DA32DF3 /* [CP] Embed Pods Frameworks */,
+				5D09BD15B81C22D5B135EB98 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SugarRecord-MacOSExample";
+			productName = "SugarRecord-ExampleMacOS";
+			productReference = 4DE9B2C01F13913300B59AEE /* SugarRecord-MacOSExample.app */;
+			productType = "com.apple.product-type.application";
+		};
 		607FACCF1AFB9204008FA782 /* SugarRecord_Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "SugarRecord_Example" */;
@@ -513,10 +758,17 @@
 		607FACC81AFB9204008FA782 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0720;
+				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
+					4DE9B2A11F138FC500B59AEE = {
+						CreatedOnToolsVersion = 9.0;
+						DevelopmentTeam = 55CX6N5J5U;
+					};
+					4DE9B2BF1F13913300B59AEE = {
+						CreatedOnToolsVersion = 9.0;
+					};
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
 						LastSwiftMigration = 0800;
@@ -541,12 +793,30 @@
 			projectRoot = "";
 			targets = (
 				607FACCF1AFB9204008FA782 /* SugarRecord_Example */,
+				4DE9B2BF1F13913300B59AEE /* SugarRecord-MacOSExample */,
 				607FACE41AFB9204008FA782 /* SugarRecord_Tests */,
+				4DE9B2A11F138FC500B59AEE /* SugarRecord_MacOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4DE9B2A01F138FC500B59AEE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DE9B2BE1F13913300B59AEE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DE9B2C71F13913300B59AEE /* Assets.xcassets in Resources */,
+				4DE9B2CA1F13913300B59AEE /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		607FACCE1AFB9204008FA782 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -581,6 +851,66 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		04B17ADE8FF538577C6429AD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SugarRecord_MacOSTests/Pods-SugarRecord_MacOSTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		04C55B11D074FA429DA32DF3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SugarRecord-MacOSExample/Pods-SugarRecord-MacOSExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0582B3662692EE134120463A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		4B48A6FF26BA0B58AF134FD3 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		5CC50519DB34147A00106131 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -594,6 +924,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SugarRecord_Example/Pods-SugarRecord_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5D09BD15B81C22D5B135EB98 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SugarRecord-MacOSExample/Pods-SugarRecord-MacOSExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A8B8DCCFD7667D0B80C5AF17 /* [CP] Copy Pods Resources */ = {
@@ -641,6 +986,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		E204E2D9D429AEED3BCF742C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SugarRecord_MacOSTests/Pods-SugarRecord_MacOSTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		FE8764C997ACB32CEF47985C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -659,6 +1019,43 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4DE9B29E1F138FC500B59AEE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DE9B2AC1F138FF900B59AEE /* CoreData.swift in Sources */,
+				4DE9B2AD1F138FF900B59AEE /* Track+CoreDataProperties.swift in Sources */,
+				4DE9B2AE1F138FF900B59AEE /* Track.swift in Sources */,
+				4DE9B2AF1F138FF900B59AEE /* DataModel.xcdatamodeld in Sources */,
+				4DE9B2B01F138FF900B59AEE /* CoreDataChangeTests.swift in Sources */,
+				4DE9B2B11F138FF900B59AEE /* CoreDataObservableTests.swift in Sources */,
+				4DE9B2B21F138FF900B59AEE /* ObjectModelTests.swift in Sources */,
+				4DE9B2B31F138FF900B59AEE /* OptionsTests.swift in Sources */,
+				4DE9B2B41F138FF900B59AEE /* StoreTests.swift in Sources */,
+				4DE9B2B51F138FF900B59AEE /* CoreDataDefaultStorageTests.swift in Sources */,
+				4DE9B2B61F138FF900B59AEE /* RequestTests.swift in Sources */,
+				4DE9B2B71F138FF900B59AEE /* DirUtilsTests.swift in Sources */,
+				4DE9B2B81F138FF900B59AEE /* VersionControllerTests.swift in Sources */,
+				4DE9B2B91F138FF900B59AEE /* VersionProviderTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DE9B2BC1F13913300B59AEE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DE9B2EC1F13A35700B59AEE /* DetailsViewController.swift in Sources */,
+				4DE9B2ED1F13A35700B59AEE /* SplitViewController.swift in Sources */,
+				4DE9B2E71F139CA200B59AEE /* Basic.xcdatamodeld in Sources */,
+				4DE9B2E51F139C3700B59AEE /* Directory.swift in Sources */,
+				4DE9B2E61F139C3700B59AEE /* Random.swift in Sources */,
+				4DE9B2E01F139B9B00B59AEE /* BasicObject.swift in Sources */,
+				4DE9B2E11F139B9B00B59AEE /* CoreDataBasicEntity.swift in Sources */,
+				4DE9B2C51F13913300B59AEE /* ListViewController.swift in Sources */,
+				4DE9B2C31F13913300B59AEE /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		607FACCC1AFB9204008FA782 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -668,9 +1065,11 @@
 				23E13E921D96899000204C82 /* AppDelegate.swift in Sources */,
 				23E13E9B1D96899000204C82 /* ViewController.swift in Sources */,
 				23FB2C061E97C8BB00432BCB /* BasicObject.swift in Sources */,
+				4DE9B2E91F13A0F600B59AEE /* SplitViewController.swift in Sources */,
 				23E13E901D96899000204C82 /* Basic.xcdatamodeld in Sources */,
 				23FB2C071E97C8BB00432BCB /* CoreDataBasicEntity.swift in Sources */,
 				23E13E991D96899000204C82 /* Directory.swift in Sources */,
+				4DE9B2EB1F13A18C00B59AEE /* DetailsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,6 +1097,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4DE9B2D21F13916400B59AEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4DE9B2BF1F13913300B59AEE /* SugarRecord-MacOSExample */;
+			targetProxy = 4DE9B2D11F13916400B59AEE /* PBXContainerItemProxy */;
+		};
 		607FACE71AFB9204008FA782 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 607FACCF1AFB9204008FA782 /* SugarRecord_Example */;
@@ -705,7 +1109,152 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		4DE9B2C81F13913300B59AEE /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4DE9B2C91F13913300B59AEE /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		4DE9B2A71F138FC600B59AEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7B2B361FEDD2996B9562BBB2 /* Pods-SugarRecord_MacOSTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 55CX6N5J5U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MacOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = com.arasthel.MacOSTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		4DE9B2A81F138FC600B59AEE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A48C60DE617E4E019B077F5A /* Pods-SugarRecord_MacOSTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 55CX6N5J5U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MacOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = com.arasthel.MacOSTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		4DE9B2CE1F13913300B59AEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 35FF60B77D16780A36BDC384 /* Pods-SugarRecord-MacOSExample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "SugarRecord-ExampleMacOS/Supporting Files/SugarRecord_ExampleMacOS.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "SugarRecord-ExampleMacOS/Supporting Files/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.SugarRecord-MacOSExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		4DE9B2CF1F13913300B59AEE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B12A993BAFFB1BD0E68DDEA2 /* Pods-SugarRecord-MacOSExample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "SugarRecord-ExampleMacOS/Supporting Files/SugarRecord_ExampleMacOS.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "SugarRecord-ExampleMacOS/Supporting Files/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.SugarRecord-MacOSExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		607FACED1AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -744,6 +1293,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -782,6 +1332,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -855,6 +1406,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4DE9B2A91F138FC600B59AEE /* Build configuration list for PBXNativeTarget "SugarRecord_MacOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DE9B2A71F138FC600B59AEE /* Debug */,
+				4DE9B2A81F138FC600B59AEE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4DE9B2CD1F13913300B59AEE /* Build configuration list for PBXNativeTarget "SugarRecord-MacOSExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DE9B2CE1F13913300B59AEE /* Debug */,
+				4DE9B2CF1F13913300B59AEE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "SugarRecord" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -901,6 +1470,16 @@
 				23E13E751D96899000204C82 /* Basic.xcdatamodel */,
 			);
 			currentVersion = 23E13E751D96899000204C82 /* Basic.xcdatamodel */;
+			path = Basic.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		4DE9B2D51F1399CA00B59AEE /* Basic.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				4DE9B2D61F1399CA00B59AEE /* Basic.xcdatamodel */,
+			);
+			currentVersion = 4DE9B2D61F1399CA00B59AEE /* Basic.xcdatamodel */;
 			path = Basic.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Example/SugarRecord/Resources/Assets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/SugarRecord/Resources/Assets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ class Presenter {
 
 > **NOTE**: This was renamed from Observable -> RequestObservable so we are no longer stomping on the RxSwift Observable namespace.
 
-**:warning: `RequestObservable` is not available for CoreData + OSX**
+**:warning: `RequestObservable` is only available for CoreData + OSX since MacOS 10.12**
 
 ## Resources
 - [Quick](https://github.com/quick/quick)

--- a/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
+++ b/SugarRecord/Source/CoreData/Entities/CoreDataObservable.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
-#if os(iOS) || os(tvOS) || os(watchOS)
 
+@available(OSX 10.12, *)
 public class CoreDataObservable<T: NSManagedObject>: RequestObservable<T>, NSFetchedResultsControllerDelegate where T:Equatable {
 
     // MARK: - Attributes
@@ -52,13 +52,23 @@ public class CoreDataObservable<T: NSManagedObject>: RequestObservable<T>, NSFet
     // MARK: - NSFetchedResultsControllerDelegate
     
     public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        
+        var index: Int?
+        var newIndex: Int?
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            index = indexPath?.row
+            newIndex = newIndexPath?.row
+        #elseif os(OSX)
+            index = indexPath?[1]
+            newIndex = newIndexPath?[1]
+        #endif
         switch type {
         case .delete:
-            self.batchChanges.append(.delete(indexPath!.row, anObject as! T))
+            self.batchChanges.append(.delete(index!, anObject as! T))
         case .insert:
-            self.batchChanges.append(.insert(newIndexPath!.row, anObject as! T))
+            self.batchChanges.append(.insert(newIndex!, anObject as! T))
         case .update:
-            self.batchChanges.append(.update(indexPath!.row, anObject as! T))
+            self.batchChanges.append(.update(index!, anObject as! T))
         default: break
         }
     }
@@ -75,4 +85,3 @@ public class CoreDataObservable<T: NSManagedObject>: RequestObservable<T>, NSFet
     }
 
 }
-#endif

--- a/SugarRecord/Source/CoreData/Storages/CoreDataDefaultStorage.swift
+++ b/SugarRecord/Source/CoreData/Storages/CoreDataDefaultStorage.swift
@@ -130,11 +130,10 @@ public class CoreDataDefaultStorage: Storage {
     
     // MARK: - Public
     
-#if os(iOS) || os(tvOS) || os(watchOS)
+    @available(OSX 10.12, *)
     public func observable<T: NSManagedObject>(request: FetchRequest<T>) -> RequestObservable<T> where T:Equatable {
         return CoreDataObservable(request: request, context: self.mainContext as! NSManagedObjectContext)
     }
-#endif
     
 }
 


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/SugarRecord/issues/338)

### Short description
Adding a MacOS example, a MacOS test target - until now, you could only use an iPhone simulator to test the code - and add support for `RequestObservable` on MacOS 10.12+.

### Solution
With this changes, the project can be tested and tried on MacOS and a part of the API that couldn't be used is now compatible.

### Implementation

- [x] Modify `CoreDataObservable` and `CoreDataDefaultStorage` so RequestObservable can be used on MacOS 10.12.
- [x] Add a MacOS example project - empty, just to be able to test it.
- [x] Add a test target with the same contents as the iOS test target. Check that it passes.
- [x] Add real code to the MacOS example - although it's probably the ugliest example I've ever coded.

### GIF
![](https://media3.giphy.com/media/3oEjHKzWpGjZb15XIA/giphy.gif)